### PR TITLE
Cleanup main

### DIFF
--- a/service/src/main/kotlin/fi/tampere/trevaka/TrevakaMain.kt
+++ b/service/src/main/kotlin/fi/tampere/trevaka/TrevakaMain.kt
@@ -4,7 +4,6 @@
 
 package fi.tampere.trevaka
 
-import mu.KotlinLogging
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
@@ -27,23 +26,9 @@ import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 @ConfigurationPropertiesScan(basePackages = ["fi.tampere.trevaka"])
 class TrevakaMain
 
-private val logger = KotlinLogging.logger {}
-
 fun main(args: Array<String>) {
-
-    val profiles = mutableListOf("trevaka")
-
-    System.getenv("VOLTTI_ENV")?.let { envString ->
-        when (envString) {
-            "dev", "test" -> profiles.add("enables_dev_api")
-            else -> {
-            }
-        }
-    }
-
-    logger.info("Parsed profiles: {}", profiles.toTypedArray())
     SpringApplicationBuilder()
         .sources(TrevakaMain::class.java)
-        .profiles(*profiles.toTypedArray())
+        .profiles("trevaka")
         .run(*args)
 }


### PR DESCRIPTION
VOLTTI_ENV based profile selection was not working because there
was a typo (enables_dev_api vs enable_dev_api). Dev api can be
enabled with SPRING_PROFILES_ACTIVE environment variable.