### PR TITLE
Compatibility changes and evaka ref update

### DIFF
--- a/service/src/main/kotlin/fi/tampere/trevaka/TampereConfig.kt
+++ b/service/src/main/kotlin/fi/tampere/trevaka/TampereConfig.kt
@@ -13,6 +13,7 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.presigner.S3Presigner
+import fi.espoo.evaka.invoicing.domain.PaymentIntegrationClient
 
 @Configuration
 class TampereConfig {
@@ -26,7 +27,12 @@ class TampereConfig {
         freeSickLeaveOnContractDays = true,
         freeAbsenceGivesADailyRefund = false,
         alwaysUseDaycareFinanceDecisionHandler = true,
+        invoiceNumberSeriesStart = 5000000000, // previously hardcoded value in use
+        paymentNumberSeriesStart = null, // Payments-feature not currently used in Tampere
     )
+
+    @Bean
+    fun paymentIntegrationClient(): PaymentIntegrationClient = PaymentIntegrationClient.FailingClient()
 
     @Bean
     fun documentService(s3Client: S3Client, s3Presigner: S3Presigner, env: BucketEnv): DocumentService =

--- a/service/src/main/kotlin/fi/tampere/trevaka/dev/TampereDevApi.kt
+++ b/service/src/main/kotlin/fi/tampere/trevaka/dev/TampereDevApi.kt
@@ -8,6 +8,8 @@ import fi.espoo.evaka.ExcludeCodeGen
 import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.domain.EvakaClock
+import fi.espoo.evaka.shared.domain.RealEvakaClock
 import fi.tampere.trevaka.database.resetTampereDatabaseForE2ETests
 import org.springframework.context.annotation.Profile
 import org.springframework.http.ResponseEntity
@@ -30,9 +32,9 @@ class TampereDevApi(
     }
 
     @PostMapping("/reset-tampere-db-for-e2e-tests")
-    fun resetTampereDatabaseForE2ETests(db: Database): ResponseEntity<Unit> {
+    fun resetTampereDatabaseForE2ETests(db: Database, clock: EvakaClock = RealEvakaClock()): ResponseEntity<Unit> {
         // Run async jobs before database reset to avoid database locks/deadlocks
-        asyncJobRunner.runPendingJobsSync()
+        asyncJobRunner.runPendingJobsSync(clock)
         asyncJobRunner.waitUntilNoRunningJobs(timeout = Duration.ofSeconds(20))
 
         db.connect { c -> c.transaction { tx -> tx.resetTampereDatabaseForE2ETests() } }


### PR DESCRIPTION
- added a no-op client bean for a new invoicing feature not used in Tampere
- added the new clock-parameter in Tampere-specific DevApi for compatibility, clock choice defaults to the implementation identical to previously implicit functionality