### PR TITLE
TREV-865: EESEC permission expansion

### DIFF
--- a/service/src/main/kotlin/fi/tampere/trevaka/security/TampereActionRuleMapping.kt
+++ b/service/src/main/kotlin/fi/tampere/trevaka/security/TampereActionRuleMapping.kt
@@ -52,6 +52,8 @@ class TampereActionRuleMapping : ActionRuleMapping {
                     ProviderType.MUNICIPAL_SCHOOL,
                     ProviderType.EXTERNAL_PURCHASED
                 ).inAnyUnit()
+            ) + sequenceOf(
+                HasUnitRole(UserRole.EARLY_CHILDHOOD_EDUCATION_SECRETARY).inAnyUnit()
             )
         }
         Action.Global.REPORTS_PAGE -> {
@@ -180,6 +182,16 @@ class TampereActionRuleMapping : ActionRuleMapping {
             @Suppress("UNCHECKED_CAST")
             action.defaultRules.asSequence() + sequenceOf(
                 HasGlobalRole(UserRole.FINANCE_ADMIN) as ScopedActionRule<in T>
+            ) + sequenceOf(
+                HasUnitRole(UserRole.EARLY_CHILDHOOD_EDUCATION_SECRETARY)
+                    .inPlacementUnitOfChild() as ScopedActionRule<in T>
+            )
+        }
+        Action.Child.CREATE_ATTENDANCE_RESERVATION -> {
+            @Suppress("UNCHECKED_CAST")
+            action.defaultRules.asSequence() + sequenceOf(
+                HasUnitRole(UserRole.EARLY_CHILDHOOD_EDUCATION_SECRETARY)
+                    .inPlacementUnitOfChild() as ScopedActionRule<in T>
             )
         }
         Action.Decision.DOWNLOAD_PDF -> {
@@ -199,14 +211,25 @@ class TampereActionRuleMapping : ActionRuleMapping {
             @Suppress("UNCHECKED_CAST")
             action.defaultRules.asSequence() + sequenceOf(
                 HasGlobalRole(UserRole.FINANCE_ADMIN) as ScopedActionRule<in T>
+            ) + sequenceOf(
+                HasUnitRole(UserRole.EARLY_CHILDHOOD_EDUCATION_SECRETARY)
+                    .inUnitOfGroup() as ScopedActionRule<in T>
             )
         }
-        Action.Group.READ_ABSENCES,
         Action.Group.READ_STAFF_ATTENDANCES,
         Action.Group.READ_CARETAKERS -> {
             @Suppress("UNCHECKED_CAST")
             action.defaultRules.asSequence() + sequenceOf(
                 HasGlobalRole(UserRole.DIRECTOR) as ScopedActionRule<in T>
+            )
+        }
+        Action.Group.READ_ABSENCES -> {
+            @Suppress("UNCHECKED_CAST")
+            action.defaultRules.asSequence() + sequenceOf(
+                HasGlobalRole(UserRole.DIRECTOR) as ScopedActionRule<in T>
+            ) + sequenceOf(
+                HasUnitRole(UserRole.EARLY_CHILDHOOD_EDUCATION_SECRETARY)
+                    .inUnitOfGroup() as ScopedActionRule<in T>
             )
         }
         Action.Invoice.READ -> {


### PR DESCRIPTION
Adds following permissions for EARLY_CHILDHOOD_EDUCATION_SECRETARY -role:
- full control of absences of children in associated units (group and child scopes)
- full control of child attendance reservations of children in associated units (child scope)
- read access to placement sketching report if associated to a unit (global scope)