### PR TITLE
Preschool assistance need decision content changes

### DIFF
--- a/frontend/tampere/employee.tsx
+++ b/frontend/tampere/employee.tsx
@@ -332,29 +332,14 @@ const customizations: EmployeeCustomizations = {
           viewOfGuardiansInfo: () => 'Kirjaa tähän huoltajien näkemys lapselle esitetystä tuesta.',
           appealInstructions: (
             <>
+              <P>
+                Tähän päätökseen tyytymätön voi tehdä kirjallisen oikaisuvaatimuksen.
+              </P>
               <H3>Oikaisuvaatimusoikeus</H3>
               <P>
-                Oikaisuvaatimuksen saa tehdä se, johon päätös on kohdistettu tai
-                jonka oikeuteen, velvollisuuteen tai etuun päätös välittömästi
-                vaikuttaa (asianosainen).
-              </P>
-              <H3>Oikaisuvaatimusaika</H3>
-              <P>
-                Oikaisuvaatimus on tehtävä 30 päivän kuluessa päätöksen
-                tiedoksisaannista.
-              </P>
-              <H3>Tiedoksisaanti</H3>
-              <P>
-                Asianosaisen katsotaan saaneen päätöksestä tiedon, jollei muuta
-                näytetä, seitsemän päivän kuluttua kirjeen lähettämisestä tai
-                saantitodistukseen tai tiedoksiantotodistukseen merkittynä
-                päivänä. Käytettäessä tavallista sähköistä tiedoksiantoa
-                asianosaisen katsotaan saaneen päätöksestä tiedon, jollei muuta
-                näytetä kolmantena päivänä viestin lähettämisestä.
-                Tiedoksisaantipäivää ei lueta määräaikaan. Jos määräajan
-                viimeinen päivä on pyhäpäivä, itsenäisyyspäivä, vapunpäivä,
-                joulu- tai juhannusaatto tai arkilauantai, saa tehtävän
-                toimittaa ensimmäisenä arkipäivänä sen jälkeen.
+                Oikaisuvaatimuksen saa tehdä se, johon päätös on kohdistettu tai jonka oikeuteen, 
+                velvollisuuteen tai etuun päätös välittömästi vaikuttaa (asianosainen). Alle 15-vuotiaan lapsen 
+                päätökseen oikaisua voi hakea lapsen huoltaja tai muu laillinen edustaja.
               </P>
               <H3>Oikaisuviranomainen</H3>
               <P>
@@ -377,7 +362,18 @@ const customizations: EmployeeCustomizations = {
                   newTab
                 />
               </P>
-              <H3>Oikaisuvaatimuksen muoto ja sisältö</H3>
+              <H3>Oikaisuvaatimusaika</H3>
+              <P>
+                Oikaisuvaatimus on tehtävä 14 päivän kuluessa päätöksen tiedoksisaannista.
+              </P>
+              <H3>Tiedoksisaanti</H3>
+              <P>
+                Asianosaisen katsotaan saaneen päätöksestä tiedon, jollei muuta näytetä, 7 päivän kuluttua 
+                kirjeen lähettämisestä, 3 päivän kuluttua sähköpostin lähettämisestä, saantitodistuksen 
+                osoittamana aikana tai erilliseen tiedoksisaantitodistukseen merkittynä aikana. 
+                Tiedoksisaantipäivää ei lueta määräaikaan. Jos määräajan viimeinen päivä on pyhäpäivä.
+              </P>
+              <H3>Oikaisuvaatimus</H3>
               <P>
                 Oikaisuvaatimus on tehtävä kirjallisesti. Myös sähköinen
                 asiakirja täyttää vaatimuksen kirjallisesta muodosta.
@@ -386,8 +382,7 @@ const customizations: EmployeeCustomizations = {
               <ul>
                 <li>
                   Oikaisuvaatimuksen tekijän nimi, kotikunta, postiosoite,
-                  puhelinnumero ja muut asian hoitamiseksi tarvittavat
-                  yhteystiedot
+                  puhelinnumero
                 </li>
                 <li>päätös, johon haetaan oikaisua</li>
                 <li>
@@ -396,18 +391,6 @@ const customizations: EmployeeCustomizations = {
                 </li>
                 <li>vaatimuksen perusteet</li>
               </ul>
-              <P>
-                Jos oikaisuvaatimuspäätös voidaan antaa tiedoksi sähköisenä
-                viestinä, yhteystietona pyydetään ilmoittamaan myös
-                sähköpostiosoite.
-              </P>
-              <P>
-                Jos oikaisuvaatimuksen tekijän puhevaltaa käyttää hänen
-                laillinen edustajansa tai asiamiehensä tai jos
-                oikaisuvaatimuksen laatijana on joku muu henkilö,
-                oikaisuvaatimuksessa on ilmoitettava myös tämän nimi ja
-                kotikunta.
-              </P>
               <P noMargin>Oikaisuvaatimukseen on liitettävä</P>
               <ul>
                 <li>
@@ -424,6 +407,10 @@ const customizations: EmployeeCustomizations = {
                   toimitettu viranomaiselle.
                 </li>
               </ul>
+              <P>
+                Asiamiehen on liitettävä valituskirjelmään valtakirja, kuten oikeudenkäynnistä hallintoasioissa
+                annetun lain (808/2019) 32 §:ssä säädetään
+              </P>
               <H3>Oikaisuvaatimuksen toimittaminen</H3>
               <P>
                 Oikaisuvaatimuskirjelmä on toimitettava oikaisuvaatimusajan

--- a/frontend/tampere/employee.tsx
+++ b/frontend/tampere/employee.tsx
@@ -283,6 +283,179 @@ const customizations: EmployeeCustomizations = {
           jurisdictionText:
             'Delegointipäätös pohjautuu Sivistys- ja kulttuurilautakunnan toimivallan siirtämiseen viranhaltijoille 14.6.2022 § 116: Varhaiskasvatuksen palvelupäällikkö päättää varhaiskasvatuslain mukaisesta tuesta ja tukipalveluista yksityisessä varhaiskasvatuksessa (Varhaiskasvatuslaki 3 a luku) ja päiväkodin johtaja päättää varhaiskasvatuslain mukaisesta tuesta ja tukipalveluista kunnallisessa varhaiskasvatuksessa (Varhaiskasvatuslaki 3 a luku)'
         },
+        assistanceNeedPreschoolDecision: {
+          validFromInfo: (
+            <div>
+              <p>
+                Valitse mistä asiasta päätös tehdään: erityisen tuen alkamisesta/jatkumisesta/päättymisestä.
+              </p>
+              <p>
+                Jos tuen voimassaolo alkaa ns. heti, kenttään laitetaan huoltajien kuulemisen päivämäärä.
+              </p>
+              <p>
+                Jos taas päätös tehdään etukäteen, kenttään laitetaan esim. lukuvuoden alkamispäivä tai muu sovittu, 
+                tulevaisuuden päivämäärä.
+              </p>
+            </div>
+          ),
+          extendedCompulsoryEducationInfoInfo: (
+            <div>
+              <p>
+                Pidennetyn oppivelvollisuuden ja samalla kertaa tehtävän erityisen tuen ensikertaisen päätöksen perusteluina tulee olla psykologinen tai lääketieteellinen lausunto, josta tulisi käydä ilmi asiantuntijan näkemys vammaisuuden asteesta. Mikäli lapselle on jo aiemmin tehty päätös pidennetystä oppivelvollisuudesta, uutta lausuntoa ei tarvita.
+              </p>
+              <p>
+                Jos lapselle on jo POV-suosituksessa suositeltu kahta esiopetusvuotta, kirjoita se tähän.
+              </p>
+              <p>
+                Kirjoita tähän, koskeeko tämä päätös pidennetyn oppivelvollisuuden ensimmäistä vai toista esiopetusvuotta.
+              </p>
+            </div>
+          ),
+          grantedAssistanceSectionInfo: (
+            <>
+              Valitse lapsen tarvitsemat palvelut tai apuvälineet. Apuvälineet, joista lapsella on jo päätös muualta, eivät sisälly tähän päätökseen.
+            </>
+          ),
+          primaryGroupInfo: (
+            <>
+              Kirjoita tähän, millaisessa ryhmässä lapsi saa esiopetusta (esim. integroitu varhaiskasvatusryhmä, esiopetusryhmä, integroitu esiopetusryhmä, esiopetuksen erityisryhmä). Ryhmän nimeä ei kirjoiteta tähän.
+            </>
+          ),
+          decisionBasisInfo: (
+            <>
+              Perustele, miksi lapsi tarvitsee mainittua tukea ja tukimuotoja.
+            </>
+          ),
+          documentBasisInfo: (
+            <>
+              Valitse, mitä asiakirjoja on tehty ennen tätä päätöstä.
+            </>
+          ),
+          heardGuardiansInfo: (
+            <div>
+              <p>
+                Kirjaa tähän millä keinoin huoltajaa on kuultu (esim. palaveri, etäyhteys, huoltajan kirjallinen vastine).
+                Jos huoltajaa ei ole kuultu, kirjaa tähän selvitys siitä, miten ja milloin hänet on kutsuttu kuultavaksi,
+                ja miten ja milloin lapsen varhaiskasvatussuunnitelma on annettu huoltajalle tiedoksi.
+              </p>
+
+              <p>
+                Kaikilla lapsen huoltajilla tulee olla mahdollisuus tulla kuulluksi.
+                Huoltaja voi tarvittaessa valtuuttaa toisen huoltajan edustamaan itseään valtakirjalla
+              </p>
+            </div>
+          ),
+          viewOfGuardiansInfo: (
+            <p>
+              Kirjaa tähän huoltajien näkemys lapselle esitetystä tuesta.
+            </p>
+          ),
+
+          appealInstructions: (
+            <>
+              <H3>Oikaisuvaatimusoikeus</H3>
+              <P>
+                Oikaisuvaatimuksen saa tehdä se, johon päätös on kohdistettu tai
+                jonka oikeuteen, velvollisuuteen tai etuun päätös välittömästi
+                vaikuttaa (asianosainen).
+              </P>
+              <H3>Oikaisuvaatimusaika</H3>
+              <P>
+                Oikaisuvaatimus on tehtävä 30 päivän kuluessa päätöksen
+                tiedoksisaannista.
+              </P>
+              <H3>Tiedoksisaanti</H3>
+              <P>
+                Asianosaisen katsotaan saaneen päätöksestä tiedon, jollei muuta
+                näytetä, seitsemän päivän kuluttua kirjeen lähettämisestä tai
+                saantitodistukseen tai tiedoksiantotodistukseen merkittynä
+                päivänä. Käytettäessä tavallista sähköistä tiedoksiantoa
+                asianosaisen katsotaan saaneen päätöksestä tiedon, jollei muuta
+                näytetä kolmantena päivänä viestin lähettämisestä.
+                Tiedoksisaantipäivää ei lueta määräaikaan. Jos määräajan
+                viimeinen päivä on pyhäpäivä, itsenäisyyspäivä, vapunpäivä,
+                joulu- tai juhannusaatto tai arkilauantai, saa tehtävän
+                toimittaa ensimmäisenä arkipäivänä sen jälkeen.
+              </P>
+              <H3>Oikaisuviranomainen</H3>
+              <P>
+                Oikaisu tehdään Länsi- ja Sisä-Suomen aluehallintovirastolle
+                (Vaasan päätoimipaikka).
+              </P>
+              <P>
+                Länsi- ja Sisä-Suomen aluehallintovirasto
+                <br />
+                Wolffintie 35
+                <br />
+                PL 200, 65101 Vaasa
+                <br />
+                faksi: 06 317 4817
+                <br />
+                sähköposti:{' '}
+                <ExternalLink
+                  href="mailto:kirjaamo.lansi@avi.fi"
+                  text="kirjaamo.lansi@avi.fi"
+                  newTab
+                />
+              </P>
+              <H3>Oikaisuvaatimuksen muoto ja sisältö</H3>
+              <P>
+                Oikaisuvaatimus on tehtävä kirjallisesti. Myös sähköinen
+                asiakirja täyttää vaatimuksen kirjallisesta muodosta.
+              </P>
+              <P noMargin>Oikaisuvaatimuksessa on ilmoitettava</P>
+              <ul>
+                <li>
+                  Oikaisuvaatimuksen tekijän nimi, kotikunta, postiosoite,
+                  puhelinnumero ja muut asian hoitamiseksi tarvittavat
+                  yhteystiedot
+                </li>
+                <li>päätös, johon haetaan oikaisua</li>
+                <li>
+                  miltä osin päätökseen haetaan oikaisua ja mitä oikaisua siihen
+                  vaaditaan tehtäväksi
+                </li>
+                <li>vaatimuksen perusteet</li>
+              </ul>
+              <P>
+                Jos oikaisuvaatimuspäätös voidaan antaa tiedoksi sähköisenä
+                viestinä, yhteystietona pyydetään ilmoittamaan myös
+                sähköpostiosoite.
+              </P>
+              <P>
+                Jos oikaisuvaatimuksen tekijän puhevaltaa käyttää hänen
+                laillinen edustajansa tai asiamiehensä tai jos
+                oikaisuvaatimuksen laatijana on joku muu henkilö,
+                oikaisuvaatimuksessa on ilmoitettava myös tämän nimi ja
+                kotikunta.
+              </P>
+              <P noMargin>Oikaisuvaatimukseen on liitettävä</P>
+              <ul>
+                <li>
+                  päätös, johon haetaan oikaisua, alkuperäisenä tai
+                  jäljennöksenä
+                </li>
+                <li>
+                  todistus siitä, minä päivänä päätös on annettu tiedoksi, tai
+                  muu selvitys oikaisuvaatimusajan alkamisen ajankohdasta
+                </li>
+                <li>
+                  asiakirjat, joihin oikaisuvaatimuksen tekijä vetoaa
+                  oikaisuvaatimuksensa tueksi, jollei niitä ole jo aikaisemmin
+                  toimitettu viranomaiselle.
+                </li>
+              </ul>
+              <H3>Oikaisuvaatimuksen toimittaminen</H3>
+              <P>
+                Oikaisuvaatimuskirjelmä on toimitettava oikaisuvaatimusajan
+                kuluessa oikaisuvaatimusviranomaiselle. Oikaisuvaatimuskirjelmän
+                tulee olla perillä oikaisuvaatimusajan viimeisenä päivänä ennen
+                viraston aukiolon päättymistä. Oikaisuvaatimuksen lähettäminen
+                postitse tai sähköisesti tapahtuu lähettäjän omalla vastuulla.
+              </P>
+            </>
+          )
+        },
         assistanceAction: {
           title: 'Tukitoimet ja tukipalvelut',
           fields: {

--- a/frontend/tampere/employee.tsx
+++ b/frontend/tampere/employee.tsx
@@ -284,7 +284,7 @@ const customizations: EmployeeCustomizations = {
             'Delegointipäätös pohjautuu Sivistys- ja kulttuurilautakunnan toimivallan siirtämiseen viranhaltijoille 14.6.2022 § 116: Varhaiskasvatuksen palvelupäällikkö päättää varhaiskasvatuslain mukaisesta tuesta ja tukipalveluista yksityisessä varhaiskasvatuksessa (Varhaiskasvatuslaki 3 a luku) ja päiväkodin johtaja päättää varhaiskasvatuslain mukaisesta tuesta ja tukipalveluista kunnallisessa varhaiskasvatuksessa (Varhaiskasvatuslaki 3 a luku)'
         },
         assistanceNeedPreschoolDecision: {
-          validFromInfo: (
+          validFromInfo: () => (
             <div>
               <p>
                 Valitse mistä asiasta päätös tehdään: erityisen tuen alkamisesta/jatkumisesta/päättymisestä.
@@ -293,12 +293,12 @@ const customizations: EmployeeCustomizations = {
                 Jos tuen voimassaolo alkaa ns. heti, kenttään laitetaan huoltajien kuulemisen päivämäärä.
               </p>
               <p>
-                Jos taas päätös tehdään etukäteen, kenttään laitetaan esim. lukuvuoden alkamispäivä tai muu sovittu, 
+                Jos taas päätös tehdään etukäteen, kenttään laitetaan esim. lukuvuoden alkamispäivä tai muu sovittu,
                 tulevaisuuden päivämäärä.
               </p>
             </div>
           ),
-          extendedCompulsoryEducationInfoInfo: (
+          extendedCompulsoryEducationInfoInfo: () => (
             <div>
               <p>
                 Pidennetyn oppivelvollisuuden ja samalla kertaa tehtävän erityisen tuen ensikertaisen päätöksen perusteluina tulee olla psykologinen tai lääketieteellinen lausunto, josta tulisi käydä ilmi asiantuntijan näkemys vammaisuuden asteesta. Mikäli lapselle on jo aiemmin tehty päätös pidennetystä oppivelvollisuudesta, uutta lausuntoa ei tarvita.
@@ -311,27 +311,11 @@ const customizations: EmployeeCustomizations = {
               </p>
             </div>
           ),
-          grantedAssistanceSectionInfo: (
-            <>
-              Valitse lapsen tarvitsemat palvelut tai apuvälineet. Apuvälineet, joista lapsella on jo päätös muualta, eivät sisälly tähän päätökseen.
-            </>
-          ),
-          primaryGroupInfo: (
-            <>
-              Kirjoita tähän, millaisessa ryhmässä lapsi saa esiopetusta (esim. integroitu varhaiskasvatusryhmä, esiopetusryhmä, integroitu esiopetusryhmä, esiopetuksen erityisryhmä). Ryhmän nimeä ei kirjoiteta tähän.
-            </>
-          ),
-          decisionBasisInfo: (
-            <>
-              Perustele, miksi lapsi tarvitsee mainittua tukea ja tukimuotoja.
-            </>
-          ),
-          documentBasisInfo: (
-            <>
-              Valitse, mitä asiakirjoja on tehty ennen tätä päätöstä.
-            </>
-          ),
-          heardGuardiansInfo: (
+          grantedAssistanceSectionInfo: () => 'Valitse lapsen tarvitsemat palvelut tai apuvälineet. Apuvälineet, joista lapsella on jo päätös muualta, eivät sisälly tähän päätökseen.',
+          primaryGroupInfo: () => 'Kirjoita tähän, millaisessa ryhmässä lapsi saa esiopetusta (esim. integroitu varhaiskasvatusryhmä, esiopetusryhmä, integroitu esiopetusryhmä, esiopetuksen erityisryhmä). Ryhmän nimeä ei kirjoiteta tähän.',
+          decisionBasisInfo: () => 'Perustele, miksi lapsi tarvitsee mainittua tukea ja tukimuotoja.',
+          documentBasisInfo: () => 'Valitse, mitä asiakirjoja on tehty ennen tätä päätöstä.',
+          heardGuardiansInfo: () => (
             <div>
               <p>
                 Kirjaa tähän millä keinoin huoltajaa on kuultu (esim. palaveri, etäyhteys, huoltajan kirjallinen vastine).
@@ -345,12 +329,7 @@ const customizations: EmployeeCustomizations = {
               </p>
             </div>
           ),
-          viewOfGuardiansInfo: (
-            <p>
-              Kirjaa tähän huoltajien näkemys lapselle esitetystä tuesta.
-            </p>
-          ),
-
+          viewOfGuardiansInfo: () => 'Kirjaa tähän huoltajien näkemys lapselle esitetystä tuesta.',
           appealInstructions: (
             <>
               <H3>Oikaisuvaatimusoikeus</H3>

--- a/frontend/tampere/fiCustomizations.tsx
+++ b/frontend/tampere/fiCustomizations.tsx
@@ -599,7 +599,105 @@ const fi: DeepPartial<Translations> = {
         ),
         jurisdictionText:
           'Delegointipäätös pohjautuu Sivistys- ja kulttuurilautakunnan toimivallan siirtämiseen viranhaltijoille 14.6.2022 § 116: Varhaiskasvatuksen palvelupäällikkö päättää varhaiskasvatuslain mukaisesta tuesta ja tukipalveluista yksityisessä varhaiskasvatuksessa (Varhaiskasvatuslaki 3 a luku) ja päiväkodin johtaja päättää varhaiskasvatuslain mukaisesta tuesta ja tukipalveluista kunnallisessa varhaiskasvatuksessa (Varhaiskasvatuslaki 3 a luku)'
-      }
+      },
+    },
+    assistancePreschoolDecisions: {
+      appealInstructions: (
+        <>
+          <P>
+            Tähän päätökseen tyytymätön voi tehdä kirjallisen oikaisuvaatimuksen.
+          </P>
+
+          <H3>Oikaisuvaatimusoikeus</H3>
+          <P>
+            Oikaisuvaatimuksen saa tehdä se, johon päätös on kohdistettu tai jonka oikeuteen,
+            velvollisuuteen tai etuun päätös välittömästi vaikuttaa (asianosainen). Alle 15-vuotiaan lapsen
+            päätökseen oikaisua voi hakea lapsen huoltaja tai muu laillinen edustaja.
+          </P>
+
+          <H3>Oikaisuviranomainen</H3>
+          <P>
+            Oikaisu tehdään Länsi- ja Sisä-Suomen aluehallintovirastolle
+            (Vaasan päätoimipaikka).
+          </P>
+          <P>
+            Länsi- ja Sisä-Suomen aluehallintovirasto
+            <br />
+            Wolffintie 35
+            <br />
+            PL 200, 65101 Vaasa
+            <br />
+            faksi: 06 317 4817
+            <br />
+            sähköposti:{' '}
+            <ExternalLink
+              href="mailto:kirjaamo.lansi@avi.fi"
+              text="kirjaamo.lansi@avi.fi"
+              newTab
+            />
+          </P>
+          <H3>Oikaisuvaatimusaika</H3>
+          <P>
+            Oikaisuvaatimus on tehtävä 14 päivän kuluessa päätöksen tiedoksisaannista.
+          </P>
+          <H3>Tiedoksisaanti</H3>
+          <P>
+            Asianosaisen katsotaan saaneen päätöksestä tiedon, jollei muuta näytetä, 7 päivän kuluttua
+            kirjeen lähettämisestä, 3 päivän kuluttua sähköpostin lähettämisestä, saantitodistuksen
+            osoittamana aikana tai erilliseen tiedoksisaantitodistukseen merkittynä aikana.
+            Tiedoksisaantipäivää ei lueta määräaikaan. Jos määräajan viimeinen päivä on pyhäpäivä.
+          </P>
+
+          <H3>Oikaisuvaatimus</H3>
+          <P>
+            Oikaisuvaatimus on tehtävä kirjallisesti. Myös sähköinen
+            asiakirja täyttää vaatimuksen kirjallisesta muodosta.
+          </P>
+          <P noMargin>Oikaisuvaatimuksessa on ilmoitettava</P>
+          <ul>
+            <li>
+              Oikaisuvaatimuksen tekijän nimi, kotikunta, postiosoite,
+              puhelinnumero
+            </li>
+            <li>päätös, johon haetaan oikaisua</li>
+            <li>
+              miltä osin päätökseen haetaan oikaisua ja mitä oikaisua siihen
+              vaaditaan tehtäväksi
+            </li>
+            <li>vaatimuksen perusteet</li>
+          </ul>
+
+          <P noMargin>Oikaisuvaatimukseen on liitettävä</P>
+          <ul>
+            <li>
+              päätös, johon haetaan oikaisua, alkuperäisenä tai
+              jäljennöksenä
+            </li>
+            <li>
+              todistus siitä, minä päivänä päätös on annettu tiedoksi, tai
+              muu selvitys oikaisuvaatimusajan alkamisen ajankohdasta
+            </li>
+            <li>
+              asiakirjat, joihin oikaisuvaatimuksen tekijä vetoaa
+              oikaisuvaatimuksensa tueksi, jollei niitä ole jo aikaisemmin
+              toimitettu viranomaiselle.
+            </li>
+          </ul>
+
+          <P>
+            Asiamiehen on liitettävä valituskirjelmään valtakirja, kuten oikeudenkäynnistä hallintoasioissa
+            annetun lain (808/2019) 32 §:ssä säädetään
+          </P>
+          <H3>Oikaisuvaatimuksen toimittaminen</H3>
+          <P>
+            Oikaisuvaatimuskirjelmä on toimitettava oikaisuvaatimusajan
+            kuluessa oikaisuvaatimusviranomaiselle. Oikaisuvaatimuskirjelmän
+            tulee olla perillä oikaisuvaatimusajan viimeisenä päivänä ennen
+            viraston aukiolon päättymistä. Oikaisuvaatimuksen lähettäminen
+            postitse tai sähköisesti tapahtuu lähettäjän omalla vastuulla.
+          </P>
+        </>
+      )
     }
   },
   placement: {

--- a/service/src/main/kotlin/fi/tampere/trevaka/template/config/TemplateConfiguration.kt
+++ b/service/src/main/kotlin/fi/tampere/trevaka/template/config/TemplateConfiguration.kt
@@ -40,5 +40,5 @@ internal class TrevakaTemplateProvider : ITemplateProvider {
     override fun getPreschoolDecisionPath(): String = "tampere/daycare/decision"
     override fun getPreparatoryDecisionPath(): String = throw Error("Not supported")
     override fun getAssistanceNeedDecisionPath(): String = "tampere/assistance/decision"
-    override fun getAssistanceNeedPreschoolDecisionPath(): String = "tampere/assistance-need-preschool/decision"
+    override fun getAssistanceNeedPreschoolDecisionPath(): String = "tampere/assistance-preschool/decision"
 }

--- a/service/src/main/resources/WEB-INF/templates/tampere/assistance-preschool/decision.html
+++ b/service/src/main/resources/WEB-INF/templates/tampere/assistance-preschool/decision.html
@@ -104,26 +104,28 @@ SPDX-License-Identifier: LGPL-2.1-or-later
         <div class="decision-details">
             <h3 th:text="#{basisDocuments}"></h3>
             <ul>
-                <li
-                        th:if="${decision.form.basisDocumentPedagogicalReport}"
-                        th:text="#{basisDocumentPedagogicalReport}"
-                ></li>
-                <li
-                        th:if="${decision.form.basisDocumentPsychologistStatement}"
-                        th:text="#{basisDocumentPsychologistStatement}"
-                ></li>
-                <li
-                        th:if="${decision.form.basisDocumentSocialReport}"
-                        th:text="#{basisDocumentSocialReport}"
-                ></li>
-                <li
-                        th:if="${decision.form.basisDocumentDoctorStatement}"
-                        th:text="#{basisDocumentDoctorStatement}"
-                ></li>
-                <li
-                        th:if="${decision.form.basisDocumentOtherOrMissing}"
-                        th:text="${decision.form.basisDocumentOtherOrMissingInfo}"
-                ></li>
+                <li th:if="${decision.form.basisDocumentPedagogicalReport}">
+                    <span th:text="#{basisDocumentPedagogicalReport}"></span>
+                    <span th:if="${decision.form.basisDocumentPedagogicalReportDate}"
+                          th:replace="~{shared/common :: format-date(${decision.form.basisDocumentPedagogicalReportDate})}"></span>
+                </li>
+                <li th:if="${decision.form.basisDocumentPsychologistStatement}">
+                    <span th:text="#{basisDocumentPsychologistStatement}"></span>
+                    <span th:if="${decision.form.basisDocumentPsychologistStatementDate}"
+                          th:replace="~{shared/common :: format-date(${decision.form.basisDocumentPsychologistStatementDate})}"></span>
+                </li>
+                <li th:if="${decision.form.basisDocumentSocialReport}">
+                    <span th:text="#{basisDocumentSocialReport}"></span>
+                    <span th:if="${decision.form.basisDocumentSocialReportDate}"
+                          th:replace="~{shared/common :: format-date(${decision.form.basisDocumentSocialReportDate})}"></span>
+                </li>
+                <li th:if="${decision.form.basisDocumentDoctorStatement}">
+                    <span th:text="#{basisDocumentDoctorStatement}"></span>
+                    <span th:if="${decision.form.basisDocumentDoctorStatementDate}"
+                          th:replace="~{shared/common :: format-date(${decision.form.basisDocumentDoctorStatementDate})}"></span>
+                </li>
+                <li th:if="${decision.form.basisDocumentOtherOrMissing}"
+                    th:text="${decision.form.basisDocumentOtherOrMissingInfo}"></li>
             </ul>
         </div>
 

--- a/service/src/main/resources/WEB-INF/templates/tampere/assistance-preschool/decision.html
+++ b/service/src/main/resources/WEB-INF/templates/tampere/assistance-preschool/decision.html
@@ -1,0 +1,221 @@
+<!--
+SPDX-FileCopyrightText: 2017-2023 City of Tampere
+
+SPDX-License-Identifier: LGPL-2.1-or-later
+-->
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="utf-8"/>
+    <style th:replace="~{tampere/shared/common.html :: css}"></style>
+</head>
+<body>
+<header th:replace="~{ tampere/shared/common :: assistanceDecisionHeader}"></header>
+<footer th:replace="~{ tampere/shared/common :: footer}"></footer>
+<div class="page first-page">
+    <address th:replace="~{ tampere/shared/common :: address}"></address>
+
+    <h1 th:text="#{decision.title}"></h1>
+    <div class="child-details">
+        <p>
+            <strong th:text="#{decision.details.child.prefix}"
+            >Lapsellenne</strong
+            >
+            <span
+                    th:text="#{decision.details.child(${decision.child.name}, ${#temporals.format(decision.child.dateOfBirth, 'd.M.yyyy')})}"
+            >Etunimi Sukunimi (s. 1.1.2000)</span
+            >
+            <br/>
+            <span th:utext="#{decision.details.date}"></span>
+            <span
+                    th:replace="~{shared/common :: date-range(${decision.form.validFrom}, ${validTo})}"
+            ></span>
+        </p>
+        <p>
+            <span th:text="#{decisionStatus}"></span>
+            <strong th:text="#{${'statuses.' + decision.status}}"></strong>
+        </p>
+    </div>
+
+    <div class="decision-details-container">
+        <h2 th:text="#{decidedAssistance}"></h2>
+
+        <div class="decision-details">
+            <h3 th:text="#{decisionType}"></h3>
+            <div th:text="#{'decisionType.' + ${decision.form.type}}"></div>
+        </div>
+
+        <div class="decision-details">
+            <h3 th:text="#{extendedCompulsoryEducationTitle}"></h3>
+            <div th:if="${decision.form.extendedCompulsoryEducation}">
+                <ul>
+                    <li th:text="#{extendedCompulsoryEducationYes}"></li>
+                </ul>
+                <div class="multi-line" th:text="${decision.form.extendedCompulsoryEducationInfo}"></div>
+            </div>
+            <div th:if="${!decision.form.extendedCompulsoryEducation}">
+                <ul>
+                    <li th:text="#{no}"></li>
+                </ul>
+            </div>
+        </div>
+
+        <div class="decision-details">
+            <h3 th:text="#{grantedServices}"></h3>
+            <ul>
+                <li th:if="${decision.form.grantedAssistanceService}" th:text="#{grantedAssistanceService}"></li>
+                <li th:if="${decision.form.grantedInterpretationService}"
+                    th:text="#{grantedInterpretationService}"></li>
+                <li th:if="${decision.form.grantedAssistiveDevices}" th:text="#{grantedAssistiveDevices}"></li>
+                <li
+                        th:if="${!decision.form.grantedAssistanceService && !decision.form.grantedInterpretationService && !decision.form.grantedAssistiveDevices}"
+                        th:text="#{grantedNothing}"
+                ></li>
+            </ul>
+        </div>
+
+        <div class="decision-details" th:if="${decision.form.grantedServicesBasis != ''}">
+            <h3 th:text="#{grantedServicesBasis}"></h3>
+            <div class="multi-line" th:text="${decision.form.grantedServicesBasis}"></div>
+        </div>
+
+        <div class="decision-details">
+            <h3 th:text="#{selectedUnit}"></h3>
+            <div>
+                <div th:text="${decision.unitName}"></div>
+                <div
+                        th:text="${decision.unitStreetAddress} + ', ' + ${decision.unitPostalCode} + ' ' + ${decision.unitPostOffice}"
+                ></div>
+            </div>
+        </div>
+
+        <div class="decision-details" th:text="#{unitMayChange}"></div>
+
+        <div class="decision-details">
+            <h3 th:text="#{primaryGroup}"></h3>
+            <div th:text="${decision.form.primaryGroup}"></div>
+        </div>
+
+        <div class="decision-details">
+            <h3 th:text="#{decisionBasis}"></h3>
+            <div class="multi-line" th:text="${decision.form.decisionBasis}"></div>
+        </div>
+
+        <div class="decision-details">
+            <h3 th:text="#{basisDocuments}"></h3>
+            <ul>
+                <li
+                        th:if="${decision.form.basisDocumentPedagogicalReport}"
+                        th:text="#{basisDocumentPedagogicalReport}"
+                ></li>
+                <li
+                        th:if="${decision.form.basisDocumentPsychologistStatement}"
+                        th:text="#{basisDocumentPsychologistStatement}"
+                ></li>
+                <li
+                        th:if="${decision.form.basisDocumentSocialReport}"
+                        th:text="#{basisDocumentSocialReport}"
+                ></li>
+                <li
+                        th:if="${decision.form.basisDocumentDoctorStatement}"
+                        th:text="#{basisDocumentDoctorStatement}"
+                ></li>
+                <li
+                        th:if="${decision.form.basisDocumentOtherOrMissing}"
+                        th:text="${decision.form.basisDocumentOtherOrMissingInfo}"
+                ></li>
+            </ul>
+        </div>
+
+        <div class="decision-details" th:if="${decision.form.basisDocumentsInfo != ''}">
+            <h3 th:text="#{basisDocumentsInfo}"></h3>
+            <div class="multi-line" th:text="${decision.form.basisDocumentsInfo}"></div>
+        </div>
+    </div>
+
+    <div class="decision-details-container">
+        <h2 th:text="#{collaborationWithGuardians}"></h2>
+        <div class="decision-details">
+            <h3 th:text="#{guardiansHeardAt}"></h3>
+            <div th:replace="~{shared/common :: format-date(${decision.form.guardiansHeardOn})}"></div>
+        </div>
+        <div class="decision-details">
+            <h3 th:text="#{guardiansHeard}"></h3>
+            <ul>
+                <li
+                        th:each="guardian : ${decision.form.guardianInfo}"
+                        th:if="${guardian.isHeard} == true"
+                >
+                    <span th:text="${guardian.name}"></span>
+                    <span
+                            th:text="': ' + ${guardian.details}"
+                            th:if="${guardian.details} != null"
+                    ></span>
+                </li>
+                <li
+                        th:if="${decision.form.otherRepresentativeHeard}"
+                        th:text="${decision.form.otherRepresentativeDetails}"
+                ></li>
+            </ul>
+        </div>
+        <div class="decision-details">
+            <h3 th:text="#{viewOfTheGuardians}"></h3>
+            <div class="multi-line" th:text="${decision.form.viewOfGuardians}"></div>
+        </div>
+    </div>
+
+    <div class="decision-details-container">
+        <h2 th:text="#{legalInstructions}"></h2>
+        <p th:text="#{legalInstructionsText}"></p>
+    </div>
+
+    <div class="decision-details-container">
+        <h2 th:text="#{jurisdiction}"></h2>
+        <p th:text="#{jurisdictionText}"></p>
+    </div>
+
+    <div class="decision-details-container">
+        <h2 th:text="#{personsResponsible}"></h2>
+        <div class="decision-details">
+            <h3 th:text="#{preparator}"></h3>
+            <div>
+                <div>
+                    <span th:text="${decision.preparer1Name}"></span>,
+                    <span th:text="${decision.form.preparer1Title}"></span>
+                </div>
+                <div th:text="${decision.form.preparer1PhoneNumber}"></div>
+            </div>
+        </div>
+        <div class="decision-details" th:if="${decision.form.preparer2EmployeeId} != null">
+            <h3 th:text="#{preparator}"></h3>
+            <div>
+                <div>
+                    <span th:text="${decision.preparer2Name}"></span>,
+                    <span th:text="${decision.form.preparer2Title}"></span>
+                </div>
+                <div th:text="${decision.form.preparer2PhoneNumber}"></div>
+            </div>
+        </div>
+        <div class="decision-details">
+            <h3 th:text="#{decisionMaker}"></h3>
+            <div>
+                <span th:text="${decision.decisionMakerName}"></span>,
+                <span th:text="${decision.form.decisionMakerTitle}"></span>
+            </div>
+        </div>
+        <p>
+            <span th:text="#{decisionMadeOn}"></span>
+            <span
+                    th:replace="~{shared/common :: format-date(${decision.decisionMade})}"
+            ></span>
+        </p>
+    </div>
+    <p th:utext="#{disclaimer}"></p>
+</div>
+
+<div class="page last-page">
+    <h1 th:text="#{appealInstructionTitle}"></h1>
+    <div th:utext="#{appealInstructions}"></div>
+</div>
+</body>
+</html>

--- a/service/src/main/resources/WEB-INF/templates/tampere/assistance-preschool/decision.properties
+++ b/service/src/main/resources/WEB-INF/templates/tampere/assistance-preschool/decision.properties
@@ -63,31 +63,18 @@ legalInstructionsText=Perusopetuslaki 17 §
 jurisdiction=Toimivalta
 jurisdictionText=Delegointipäätös suomenkielisen varhaiskasvatuksen sekä kasvun ja oppimisen toimialan esikunnan viranhaltijoiden ratkaisuvallasta A osa 3 § 3 kohta
 
-appealInstructionTitle=Oikaisuvaatimusohje
+appealInstructionTitle=Oikaisuvaatimus
 appealInstructions=\
+  <p>§</p>\
+  <h2>Oikaisuvaatimusohje</h2>\
+  <p>\
+    Tähän päätökseen tyytymätön voi tehdä kirjallisen oikaisuvaatimuksen.\
+  </p>\
   <h2>Oikaisuvaatimusoikeus</h2>\
   <p>\
-    Oikaisuvaatimuksen saa tehdä se, johon päätös on kohdistettu tai \
-    jonka oikeuteen, velvollisuuteen tai etuun päätös välittömästi \
-    vaikuttaa (asianosainen).\
-  </p>\
-  <h2>Oikaisuvaatimusaika</h2>\
-  <p>\
-    Oikaisuvaatimus on tehtävä 30 päivän kuluessa päätöksen \
-    tiedoksisaannista.\
-  </p>\
-  <h2>Tiedoksisaanti</h2>\
-  <p>\
-    Asianosaisen katsotaan saaneen päätöksestä tiedon, jollei muuta \
-    näytetä, seitsemän päivän kuluttua kirjeen lähettämisestä tai \
-    saantitodistukseen tai tiedoksiantotodistukseen merkittynä \
-    päivänä. Käytettäessä tavallista sähköistä tiedoksiantoa \
-    asianosaisen katsotaan saaneen päätöksestä tiedon, jollei muuta \
-    näytetä kolmantena päivänä viestin lähettämisestä. \
-    Tiedoksisaantipäivää ei lueta määräaikaan. Jos määräajan \
-    viimeinen päivä on pyhäpäivä, itsenäisyyspäivä, vapunpäivä, \
-    joulu- tai juhannusaatto tai arkilauantai, saa tehtävän \
-    toimittaa ensimmäisenä arkipäivänä sen jälkeen. \
+    Oikaisuvaatimuksen saa tehdä se, johon päätös on kohdistettu tai jonka oikeuteen, \
+    velvollisuuteen tai etuun päätös välittömästi vaikuttaa (asianosainen). Alle 15-vuotiaan lapsen \
+    päätökseen oikaisua voi hakea lapsen huoltaja tai muu laillinen edustaja. \
   </p>\
   <h2>Oikaisuviranomainen</h2>\
   <p>Oikaisu tehdään Länsi- ja Sisä-Suomen aluehallintovirastolle (Vaasan päätoimipaikka).</p>\
@@ -102,17 +89,24 @@ appealInstructions=\
     <br />\
     sähköposti: <a href="mailto:kirjaamo.lansi@avi.fi">kirjaamo.lansi@avi.fi</a>\
   </p>\
-  <h2>Oikaisuvaatimuksen muoto ja sisältö</h2>\
+  <h2>Oikaisuvaatimusaika</h2>\
   <p>\
-    Oikaisuvaatimus on tehtävä kirjallisesti. Myös sähköinen \
-    asiakirja täyttää vaatimuksen kirjallisesta muodosta.\
+    Oikaisuvaatimus on tehtävä 14 päivän kuluessa päätöksen tiedoksisaannista. \
   </p>\
+  <h2>Tiedoksisaanti</h2>\
+  <p>\
+    Asianosaisen katsotaan saaneen päätöksestä tiedon, jollei muuta näytetä, 7 päivän kuluttua \
+    kirjeen lähettämisestä, 3 päivän kuluttua sähköpostin lähettämisestä, saantitodistuksen \
+    osoittamana aikana tai erilliseen tiedoksisaantitodistukseen merkittynä aikana. \
+    Tiedoksisaantipäivää ei lueta määräaikaan. Jos määräajan viimeinen päivä on pyhäpäivä, \
+    itsenäisyyspäivä, vapunpäivä, joulu- tai juhannusaatto tai arkilauantai, saa tehtävän toimittaa \
+    ensimmäisenä arkipäivänä sen jälkeen. \
+  </p>\
+  <h2>Oikaisuvaatimus</h2>\
   <p>Oikaisuvaatimuksessa on ilmoitettava</p>\
   <ul>\
     <li>\
-      Oikaisuvaatimuksen tekijän nimi, kotikunta, postiosoite, \
-      puhelinnumero ja muut asian hoitamiseksi tarvittavat \
-      yhteystiedot \
+      Oikaisuvaatimuksen tekijän nimi, kotikunta, postiosoite ja puhelinnumero\
     </li>\
     <li>päätös, johon haetaan oikaisua</li>\
     <li>\
@@ -121,18 +115,6 @@ appealInstructions=\
     </li>\
     <li>vaatimuksen perusteet</li>\
   </ul>\
-  <p>\
-    Jos oikaisuvaatimuspäätös voidaan antaa tiedoksi sähköisenä \
-    viestinä, yhteystietona pyydetään ilmoittamaan myös \
-    sähköpostiosoite.\
-  </p>\
-  <p>\
-    Jos oikaisuvaatimuksen tekijän puhevaltaa käyttää hänen \
-    laillinen edustajansa tai asiamiehensä tai jos \
-    oikaisuvaatimuksen laatijana on joku muu henkilö, \
-    oikaisuvaatimuksessa on ilmoitettava myös tämän nimi ja \
-    kotikunta.\
-  </p>\
   <p>Oikaisuvaatimukseen on liitettävä</p>\
   <ul>\
     <li>\
@@ -149,11 +131,14 @@ appealInstructions=\
       toimitettu viranomaiselle.\
     </li>\
   </ul>\
+  <p>\
+    Asiamiehen on liitettävä valituskirjelmään valtakirja, kuten oikeudenkäynnistä hallintoasioissa \
+    annetun lain (808/2019) 32 §:ssä säädetään.\
+  </p>\
   <h2>Oikaisuvaatimuksen toimittaminen</h2>\
   <p>\
-    Oikaisuvaatimuskirjelmä on toimitettava oikaisuvaatimusajan \
-    kuluessa oikaisuvaatimusviranomaiselle. Oikaisuvaatimuskirjelmän \
-    tulee olla perillä oikaisuvaatimusajan viimeisenä päivänä ennen \
-    viraston aukiolon päättymistä. Oikaisuvaatimuksen lähettäminen \
+    Oikaisuvaatimuskirjelmä on toimitettava oikaisuvaatimusajan kuluessa \
+    oikaisuvaatimusviranomaiselle. Oikaisuvaatimuskirjelmän tulee olla perillä oikaisuvaatimusajan \
+    viimeisenä päivänä ennen viraston aukiolon päättymistä. Oikaisuvaatimuksen lähettäminen \
     postitse tai sähköisesti tapahtuu lähettäjän omalla vastuulla.\
   </p>

--- a/service/src/main/resources/WEB-INF/templates/tampere/assistance-preschool/decision.properties
+++ b/service/src/main/resources/WEB-INF/templates/tampere/assistance-preschool/decision.properties
@@ -49,7 +49,7 @@ personsResponsible=Vastuuhenkilöt
 preparator=Päätöksen valmistelija
 decisionMaker=Päätöksen tekijä
 title=Titteli
-disclaimer=Varhaiskasvatuslain 15 e §:n mukaan tämä päätös voidaan panna täytäntöön muutoksenhausta huolimatta.
+disclaimer=Perusopetuslain 17 §:n mukaan tämä päätös voidaan panna täytäntöön muutoksenhausta huolimatta.
 
 statuses.ACCEPTED=hyväksytty
 statuses.REJECTED=hylätty
@@ -59,7 +59,7 @@ decisionMadeOn=Päätetty
 no=Ei
 
 legalInstructions=Sovelletut oikeusohjeet
-legalInstructionsText=Varhaiskasvatuslaki, 3 a luku
+legalInstructionsText=Perusopetuslaki 17 §
 jurisdiction=Toimivalta
 jurisdictionText=Delegointipäätös suomenkielisen varhaiskasvatuksen sekä kasvun ja oppimisen toimialan esikunnan viranhaltijoiden ratkaisuvallasta A osa 3 § 3 kohta
 

--- a/service/src/main/resources/WEB-INF/templates/tampere/assistance-preschool/decision.properties
+++ b/service/src/main/resources/WEB-INF/templates/tampere/assistance-preschool/decision.properties
@@ -67,27 +67,27 @@ appealInstructionTitle=Oikaisuvaatimusohje
 appealInstructions=\
   <h2>Oikaisuvaatimusoikeus</h2>\
   <p>\
-    Oikaisuvaatimuksen saa tehdä se, johon päätös on kohdistettu tai\
-    jonka oikeuteen, velvollisuuteen tai etuun päätös välittömästi\
+    Oikaisuvaatimuksen saa tehdä se, johon päätös on kohdistettu tai \
+    jonka oikeuteen, velvollisuuteen tai etuun päätös välittömästi \
     vaikuttaa (asianosainen).\
   </p>\
   <h2>Oikaisuvaatimusaika</h2>\
   <p>\
-    Oikaisuvaatimus on tehtävä 30 päivän kuluessa päätöksen\
+    Oikaisuvaatimus on tehtävä 30 päivän kuluessa päätöksen \
     tiedoksisaannista.\
   </p>\
   <h2>Tiedoksisaanti</h2>\
   <p>\
-    Asianosaisen katsotaan saaneen päätöksestä tiedon, jollei muuta\
-    näytetä, seitsemän päivän kuluttua kirjeen lähettämisestä tai\
-    saantitodistukseen tai tiedoksiantotodistukseen merkittynä\
-    päivänä. Käytettäessä tavallista sähköistä tiedoksiantoa\
-    asianosaisen katsotaan saaneen päätöksestä tiedon, jollei muuta\
-    näytetä kolmantena päivänä viestin lähettämisestä.\
-    Tiedoksisaantipäivää ei lueta määräaikaan. Jos määräajan\
-    viimeinen päivä on pyhäpäivä, itsenäisyyspäivä, vapunpäivä,\
-    joulu- tai juhannusaatto tai arkilauantai, saa tehtävän\
-    toimittaa ensimmäisenä arkipäivänä sen jälkeen.\
+    Asianosaisen katsotaan saaneen päätöksestä tiedon, jollei muuta \
+    näytetä, seitsemän päivän kuluttua kirjeen lähettämisestä tai \
+    saantitodistukseen tai tiedoksiantotodistukseen merkittynä \
+    päivänä. Käytettäessä tavallista sähköistä tiedoksiantoa \
+    asianosaisen katsotaan saaneen päätöksestä tiedon, jollei muuta \
+    näytetä kolmantena päivänä viestin lähettämisestä. \
+    Tiedoksisaantipäivää ei lueta määräaikaan. Jos määräajan \
+    viimeinen päivä on pyhäpäivä, itsenäisyyspäivä, vapunpäivä, \
+    joulu- tai juhannusaatto tai arkilauantai, saa tehtävän \
+    toimittaa ensimmäisenä arkipäivänä sen jälkeen. \
   </p>\
   <h2>Oikaisuviranomainen</h2>\
   <p>Oikaisu tehdään Länsi- ja Sisä-Suomen aluehallintovirastolle (Vaasan päätoimipaikka).</p>\
@@ -104,56 +104,56 @@ appealInstructions=\
   </p>\
   <h2>Oikaisuvaatimuksen muoto ja sisältö</h2>\
   <p>\
-    Oikaisuvaatimus on tehtävä kirjallisesti. Myös sähköinen\
+    Oikaisuvaatimus on tehtävä kirjallisesti. Myös sähköinen \
     asiakirja täyttää vaatimuksen kirjallisesta muodosta.\
   </p>\
   <p>Oikaisuvaatimuksessa on ilmoitettava</p>\
   <ul>\
     <li>\
-      Oikaisuvaatimuksen tekijän nimi, kotikunta, postiosoite,\
-      puhelinnumero ja muut asian hoitamiseksi tarvittavat\
-      yhteystiedot\
+      Oikaisuvaatimuksen tekijän nimi, kotikunta, postiosoite, \
+      puhelinnumero ja muut asian hoitamiseksi tarvittavat \
+      yhteystiedot \
     </li>\
     <li>päätös, johon haetaan oikaisua</li>\
     <li>\
-      miltä osin päätökseen haetaan oikaisua ja mitä oikaisua siihen\
+      miltä osin päätökseen haetaan oikaisua ja mitä oikaisua siihen \
       vaaditaan tehtäväksi\
     </li>\
     <li>vaatimuksen perusteet</li>\
   </ul>\
   <p>\
-    Jos oikaisuvaatimuspäätös voidaan antaa tiedoksi sähköisenä\
-    viestinä, yhteystietona pyydetään ilmoittamaan myös\
+    Jos oikaisuvaatimuspäätös voidaan antaa tiedoksi sähköisenä \
+    viestinä, yhteystietona pyydetään ilmoittamaan myös \
     sähköpostiosoite.\
   </p>\
   <p>\
-    Jos oikaisuvaatimuksen tekijän puhevaltaa käyttää hänen\
-    laillinen edustajansa tai asiamiehensä tai jos\
-    oikaisuvaatimuksen laatijana on joku muu henkilö,\
-    oikaisuvaatimuksessa on ilmoitettava myös tämän nimi ja\
+    Jos oikaisuvaatimuksen tekijän puhevaltaa käyttää hänen \
+    laillinen edustajansa tai asiamiehensä tai jos \
+    oikaisuvaatimuksen laatijana on joku muu henkilö, \
+    oikaisuvaatimuksessa on ilmoitettava myös tämän nimi ja \
     kotikunta.\
   </p>\
   <p>Oikaisuvaatimukseen on liitettävä</p>\
   <ul>\
     <li>\
-      päätös, johon haetaan oikaisua, alkuperäisenä tai\
+      päätös, johon haetaan oikaisua, alkuperäisenä tai \
       jäljennöksenä\
     </li>\
     <li>\
-      todistus siitä, minä päivänä päätös on annettu tiedoksi, tai\
+      todistus siitä, minä päivänä päätös on annettu tiedoksi, tai \
       muu selvitys oikaisuvaatimusajan alkamisen ajankohdasta\
     </li>\
     <li>\
-      asiakirjat, joihin oikaisuvaatimuksen tekijä vetoaa\
-      oikaisuvaatimuksensa tueksi, jollei niitä ole jo aikaisemmin\
+      asiakirjat, joihin oikaisuvaatimuksen tekijä vetoaa \
+      oikaisuvaatimuksensa tueksi, jollei niitä ole jo aikaisemmin \
       toimitettu viranomaiselle.\
     </li>\
   </ul>\
   <h2>Oikaisuvaatimuksen toimittaminen</h2>\
   <p>\
-    Oikaisuvaatimuskirjelmä on toimitettava oikaisuvaatimusajan\
-    kuluessa oikaisuvaatimusviranomaiselle. Oikaisuvaatimuskirjelmän\
-    tulee olla perillä oikaisuvaatimusajan viimeisenä päivänä ennen\
-    viraston aukiolon päättymistä. Oikaisuvaatimuksen lähettäminen\
+    Oikaisuvaatimuskirjelmä on toimitettava oikaisuvaatimusajan \
+    kuluessa oikaisuvaatimusviranomaiselle. Oikaisuvaatimuskirjelmän \
+    tulee olla perillä oikaisuvaatimusajan viimeisenä päivänä ennen \
+    viraston aukiolon päättymistä. Oikaisuvaatimuksen lähettäminen \
     postitse tai sähköisesti tapahtuu lähettäjän omalla vastuulla.\
   </p>

--- a/service/src/main/resources/WEB-INF/templates/tampere/assistance-preschool/decision.properties
+++ b/service/src/main/resources/WEB-INF/templates/tampere/assistance-preschool/decision.properties
@@ -1,0 +1,159 @@
+# SPDX-FileCopyrightText: 2017-2023 City of Tampere
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+header.1=PÄÄTÖS
+header.2=tuesta esiopetuksessa
+header.3=<strong>Salassa pidettävä</strong><br />Perusopetuslaki 40 §
+
+decision.title=PÄÄTÖS TUESTA ESIOPETUKSESSA
+
+decision.details.child.prefix=Lapsellenne
+decision.details.child={0} (s. {1})
+decision.details.date=<strong>on tehty päätös tuesta esiopetuksessa ajalle</strong>
+
+decidedAssistance=Päätettävä tuki
+decisionType=Erityisen tuen tila
+decisionType.NEW=Erityinen tuki alkaa
+decisionType.CONTINUING=Erityinen tuki jatkuu
+decisionType.TERMINATED=Erityinen tuki päättyy
+extendedCompulsoryEducationTitle=Lapsella on pidennetty oppivelvollisuus
+extendedCompulsoryEducationYes=Kyllä, lapsella on pidennetty oppivelvollisuus
+grantedServices=Myönnettävät tulkitsemis- ja avustajapalvelut tai erityiset apuvälineet
+grantedAssistanceService=Lapselle myönnetään avustajapalveluita
+grantedInterpretationService=Lapselle myönnetään tulkitsemispalveluita
+grantedAssistiveDevices=Lapselle myönnetään erityisiä apuvälineitä
+grantedNothing=Ei valintaa
+grantedServicesBasis=Perustelut myönnettäville tulkitsemis- ja avustajapalveluille ja apuvälineille
+primaryGroup=Pääsääntöinen opetusryhmä
+decisionBasis=Perustelut päätökselle
+basisDocuments=Asiakirjat, joihin päätös perustuu
+basisDocumentPedagogicalReport=Pedagoginen selvitys
+basisDocumentPsychologistStatement=Psykologin lausunto
+basisDocumentSocialReport=Sosiaalinen selvitys
+basisDocumentDoctorStatement=Lääkärin lausunto
+basisDocumentsInfo=Lisätiedot liitteistä
+
+collaborationWithGuardians=Huoltajien kanssa tehty yhteistyö
+guardiansHeardAt=Huoltajien kuulemisen päivämäärä
+guardiansHeard=Huoltajat, joita on kuultu, ja kuulemistapa
+viewOfTheGuardians=Huoltajien näkemys esitetystä tuesta
+
+startDate=Tuki voimassa alkaen
+endDate=Päätös voimassa saakka
+
+selectedUnit=Päätökselle valittu esiopetusyksikkö
+unitMayChange=Loma-aikoina tuen järjestämispaikka ja -tapa saattavat muuttua.
+
+personsResponsible=Vastuuhenkilöt
+preparator=Päätöksen valmistelija
+decisionMaker=Päätöksen tekijä
+title=Titteli
+disclaimer=Varhaiskasvatuslain 15 e §:n mukaan tämä päätös voidaan panna täytäntöön muutoksenhausta huolimatta.
+
+statuses.ACCEPTED=hyväksytty
+statuses.REJECTED=hylätty
+decisionStatus=Päätös on
+decisionMadeOn=Päätetty
+
+no=Ei
+
+legalInstructions=Sovelletut oikeusohjeet
+legalInstructionsText=Varhaiskasvatuslaki, 3 a luku
+jurisdiction=Toimivalta
+jurisdictionText=Delegointipäätös suomenkielisen varhaiskasvatuksen sekä kasvun ja oppimisen toimialan esikunnan viranhaltijoiden ratkaisuvallasta A osa 3 § 3 kohta
+
+appealInstructionTitle=Oikaisuvaatimusohje
+appealInstructions=\
+  <h2>Oikaisuvaatimusoikeus</h2>\
+  <p>\
+    Oikaisuvaatimuksen saa tehdä se, johon päätös on kohdistettu tai\
+    jonka oikeuteen, velvollisuuteen tai etuun päätös välittömästi\
+    vaikuttaa (asianosainen).\
+  </p>\
+  <h2>Oikaisuvaatimusaika</h2>\
+  <p>\
+    Oikaisuvaatimus on tehtävä 30 päivän kuluessa päätöksen\
+    tiedoksisaannista.\
+  </p>\
+  <h2>Tiedoksisaanti</h2>\
+  <p>\
+    Asianosaisen katsotaan saaneen päätöksestä tiedon, jollei muuta\
+    näytetä, seitsemän päivän kuluttua kirjeen lähettämisestä tai\
+    saantitodistukseen tai tiedoksiantotodistukseen merkittynä\
+    päivänä. Käytettäessä tavallista sähköistä tiedoksiantoa\
+    asianosaisen katsotaan saaneen päätöksestä tiedon, jollei muuta\
+    näytetä kolmantena päivänä viestin lähettämisestä.\
+    Tiedoksisaantipäivää ei lueta määräaikaan. Jos määräajan\
+    viimeinen päivä on pyhäpäivä, itsenäisyyspäivä, vapunpäivä,\
+    joulu- tai juhannusaatto tai arkilauantai, saa tehtävän\
+    toimittaa ensimmäisenä arkipäivänä sen jälkeen.\
+  </p>\
+  <h2>Oikaisuviranomainen</h2>\
+  <p>Oikaisu tehdään Länsi- ja Sisä-Suomen aluehallintovirastolle (Vaasan päätoimipaikka).</p>\
+  <p>\
+    Länsi- ja Sisä-Suomen aluehallintovirasto\
+    <br />\
+    Wolffintie 35\
+    <br />\
+    PL 200, 65101 Vaasa\
+    <br />\
+    faksi: 06 317 4817\
+    <br />\
+    sähköposti: <a href="mailto:kirjaamo.lansi@avi.fi">kirjaamo.lansi@avi.fi</a>\
+  </p>\
+  <h2>Oikaisuvaatimuksen muoto ja sisältö</h2>\
+  <p>\
+    Oikaisuvaatimus on tehtävä kirjallisesti. Myös sähköinen\
+    asiakirja täyttää vaatimuksen kirjallisesta muodosta.\
+  </p>\
+  <p>Oikaisuvaatimuksessa on ilmoitettava</p>\
+  <ul>\
+    <li>\
+      Oikaisuvaatimuksen tekijän nimi, kotikunta, postiosoite,\
+      puhelinnumero ja muut asian hoitamiseksi tarvittavat\
+      yhteystiedot\
+    </li>\
+    <li>päätös, johon haetaan oikaisua</li>\
+    <li>\
+      miltä osin päätökseen haetaan oikaisua ja mitä oikaisua siihen\
+      vaaditaan tehtäväksi\
+    </li>\
+    <li>vaatimuksen perusteet</li>\
+  </ul>\
+  <p>\
+    Jos oikaisuvaatimuspäätös voidaan antaa tiedoksi sähköisenä\
+    viestinä, yhteystietona pyydetään ilmoittamaan myös\
+    sähköpostiosoite.\
+  </p>\
+  <p>\
+    Jos oikaisuvaatimuksen tekijän puhevaltaa käyttää hänen\
+    laillinen edustajansa tai asiamiehensä tai jos\
+    oikaisuvaatimuksen laatijana on joku muu henkilö,\
+    oikaisuvaatimuksessa on ilmoitettava myös tämän nimi ja\
+    kotikunta.\
+  </p>\
+  <p>Oikaisuvaatimukseen on liitettävä</p>\
+  <ul>\
+    <li>\
+      päätös, johon haetaan oikaisua, alkuperäisenä tai\
+      jäljennöksenä\
+    </li>\
+    <li>\
+      todistus siitä, minä päivänä päätös on annettu tiedoksi, tai\
+      muu selvitys oikaisuvaatimusajan alkamisen ajankohdasta\
+    </li>\
+    <li>\
+      asiakirjat, joihin oikaisuvaatimuksen tekijä vetoaa\
+      oikaisuvaatimuksensa tueksi, jollei niitä ole jo aikaisemmin\
+      toimitettu viranomaiselle.\
+    </li>\
+  </ul>\
+  <h2>Oikaisuvaatimuksen toimittaminen</h2>\
+  <p>\
+    Oikaisuvaatimuskirjelmä on toimitettava oikaisuvaatimusajan\
+    kuluessa oikaisuvaatimusviranomaiselle. Oikaisuvaatimuskirjelmän\
+    tulee olla perillä oikaisuvaatimusajan viimeisenä päivänä ennen\
+    viraston aukiolon päättymistä. Oikaisuvaatimuksen lähettäminen\
+    postitse tai sähköisesti tapahtuu lähettäjän omalla vastuulla.\
+  </p>

--- a/service/src/main/resources/WEB-INF/templates/tampere/assistance/decision.properties
+++ b/service/src/main/resources/WEB-INF/templates/tampere/assistance/decision.properties
@@ -65,26 +65,26 @@ appealInstructionTitle=Oikaisuvaatimusohje
 appealInstructions=\
   <h2>Oikaisuvaatimusoikeus</h2>\
   <p>\
-    Oikaisuvaatimuksen saa tehdä se, johon päätös on kohdistettu tai\
-    jonka oikeuteen, velvollisuuteen tai etuun päätös välittömästi\
+    Oikaisuvaatimuksen saa tehdä se, johon päätös on kohdistettu tai \
+    jonka oikeuteen, velvollisuuteen tai etuun päätös välittömästi \
     vaikuttaa (asianosainen).\
   </p>\
   <h2>Oikaisuvaatimusaika</h2>\
   <p>\
-    Oikaisuvaatimus on tehtävä 30 päivän kuluessa päätöksen\
+    Oikaisuvaatimus on tehtävä 30 päivän kuluessa päätöksen \
     tiedoksisaannista.\
   </p>\
   <h2>Tiedoksisaanti</h2>\
   <p>\
-    Asianosaisen katsotaan saaneen päätöksestä tiedon, jollei muuta\
-    näytetä, seitsemän päivän kuluttua kirjeen lähettämisestä tai\
-    saantitodistukseen tai tiedoksiantotodistukseen merkittynä\
-    päivänä. Käytettäessä tavallista sähköistä tiedoksiantoa\
-    asianosaisen katsotaan saaneen päätöksestä tiedon, jollei muuta\
-    näytetä kolmantena päivänä viestin lähettämisestä.\
-    Tiedoksisaantipäivää ei lueta määräaikaan. Jos määräajan\
-    viimeinen päivä on pyhäpäivä, itsenäisyyspäivä, vapunpäivä,\
-    joulu- tai juhannusaatto tai arkilauantai, saa tehtävän\
+    Asianosaisen katsotaan saaneen päätöksestä tiedon, jollei muuta \
+    näytetä, seitsemän päivän kuluttua kirjeen lähettämisestä tai \
+    saantitodistukseen tai tiedoksiantotodistukseen merkittynä \
+    päivänä. Käytettäessä tavallista sähköistä tiedoksiantoa \
+    asianosaisen katsotaan saaneen päätöksestä tiedon, jollei muuta \
+    näytetä kolmantena päivänä viestin lähettämisestä. \
+    Tiedoksisaantipäivää ei lueta määräaikaan. Jos määräajan \
+    viimeinen päivä on pyhäpäivä, itsenäisyyspäivä, vapunpäivä, \
+    joulu- tai juhannusaatto tai arkilauantai, saa tehtävän \
     toimittaa ensimmäisenä arkipäivänä sen jälkeen.\
   </p>\
   <h2>Oikaisuviranomainen</h2>\
@@ -102,56 +102,56 @@ appealInstructions=\
   </p>\
   <h2>Oikaisuvaatimuksen muoto ja sisältö</h2>\
   <p>\
-    Oikaisuvaatimus on tehtävä kirjallisesti. Myös sähköinen\
+    Oikaisuvaatimus on tehtävä kirjallisesti. Myös sähköinen \
     asiakirja täyttää vaatimuksen kirjallisesta muodosta.\
   </p>\
   <p>Oikaisuvaatimuksessa on ilmoitettava</p>\
   <ul>\
     <li>\
-      Oikaisuvaatimuksen tekijän nimi, kotikunta, postiosoite,\
-      puhelinnumero ja muut asian hoitamiseksi tarvittavat\
+      Oikaisuvaatimuksen tekijän nimi, kotikunta, postiosoite, \
+      puhelinnumero ja muut asian hoitamiseksi tarvittavat \
       yhteystiedot\
     </li>\
     <li>päätös, johon haetaan oikaisua</li>\
     <li>\
-      miltä osin päätökseen haetaan oikaisua ja mitä oikaisua siihen\
+      miltä osin päätökseen haetaan oikaisua ja mitä oikaisua siihen \
       vaaditaan tehtäväksi\
     </li>\
     <li>vaatimuksen perusteet</li>\
   </ul>\
   <p>\
-    Jos oikaisuvaatimuspäätös voidaan antaa tiedoksi sähköisenä\
-    viestinä, yhteystietona pyydetään ilmoittamaan myös\
+    Jos oikaisuvaatimuspäätös voidaan antaa tiedoksi sähköisenä \
+    viestinä, yhteystietona pyydetään ilmoittamaan myös \
     sähköpostiosoite.\
   </p>\
   <p>\
-    Jos oikaisuvaatimuksen tekijän puhevaltaa käyttää hänen\
-    laillinen edustajansa tai asiamiehensä tai jos\
-    oikaisuvaatimuksen laatijana on joku muu henkilö,\
-    oikaisuvaatimuksessa on ilmoitettava myös tämän nimi ja\
+    Jos oikaisuvaatimuksen tekijän puhevaltaa käyttää hänen \
+    laillinen edustajansa tai asiamiehensä tai jos \
+    oikaisuvaatimuksen laatijana on joku muu henkilö, \
+    oikaisuvaatimuksessa on ilmoitettava myös tämän nimi ja \
     kotikunta.\
   </p>\
   <p>Oikaisuvaatimukseen on liitettävä</p>\
   <ul>\
     <li>\
-      päätös, johon haetaan oikaisua, alkuperäisenä tai\
+      päätös, johon haetaan oikaisua, alkuperäisenä tai \
       jäljennöksenä\
     </li>\
     <li>\
-      todistus siitä, minä päivänä päätös on annettu tiedoksi, tai\
+      todistus siitä, minä päivänä päätös on annettu tiedoksi, tai \
       muu selvitys oikaisuvaatimusajan alkamisen ajankohdasta\
     </li>\
     <li>\
-      asiakirjat, joihin oikaisuvaatimuksen tekijä vetoaa\
-      oikaisuvaatimuksensa tueksi, jollei niitä ole jo aikaisemmin\
+      asiakirjat, joihin oikaisuvaatimuksen tekijä vetoaa \
+      oikaisuvaatimuksensa tueksi, jollei niitä ole jo aikaisemmin \
       toimitettu viranomaiselle.\
     </li>\
   </ul>\
   <h2>Oikaisuvaatimuksen toimittaminen</h2>\
   <p>\
-    Oikaisuvaatimuskirjelmä on toimitettava oikaisuvaatimusajan\
-    kuluessa oikaisuvaatimusviranomaiselle. Oikaisuvaatimuskirjelmän\
-    tulee olla perillä oikaisuvaatimusajan viimeisenä päivänä ennen\
-    viraston aukiolon päättymistä. Oikaisuvaatimuksen lähettäminen\
+    Oikaisuvaatimuskirjelmä on toimitettava oikaisuvaatimusajan \
+    kuluessa oikaisuvaatimusviranomaiselle. Oikaisuvaatimuskirjelmän \
+    tulee olla perillä oikaisuvaatimusajan viimeisenä päivänä ennen \
+    viraston aukiolon päättymistä. Oikaisuvaatimuksen lähettäminen \
     postitse tai sähköisesti tapahtuu lähettäjän omalla vastuulla.\
   </p>

--- a/service/src/test/kotlin/fi/tampere/trevaka/assistanceneed/decision/PreschoolAssistanceNeedDecisionServiceTest.kt
+++ b/service/src/test/kotlin/fi/tampere/trevaka/assistanceneed/decision/PreschoolAssistanceNeedDecisionServiceTest.kt
@@ -156,6 +156,10 @@ private val validAssistanceNeedPreschoolDecisionForm =
         preparer2PhoneNumber = "",
         decisionMakerEmployeeId = EmployeeId(UUID.randomUUID()),
         decisionMakerTitle = "Päätöksentekijän titteli",
+        basisDocumentDoctorStatementDate = LocalDate.of(2022, 8, 2),
+        basisDocumentPedagogicalReportDate = LocalDate.of(2022, 8, 2),
+        basisDocumentPsychologistStatementDate = LocalDate.of(2022, 8, 2),
+        basisDocumentSocialReportDate = LocalDate.of(2022, 8, 2),
     )
 
 private val validAssistanceNeedPreschoolDecision =

--- a/service/src/test/kotlin/fi/tampere/trevaka/assistanceneed/decision/PreschoolAssistanceNeedDecisionServiceTest.kt
+++ b/service/src/test/kotlin/fi/tampere/trevaka/assistanceneed/decision/PreschoolAssistanceNeedDecisionServiceTest.kt
@@ -1,0 +1,310 @@
+// SPDX-FileCopyrightText: 2021-2022 City of Tampere
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.tampere.trevaka.assistanceneed.decision
+
+import fi.espoo.evaka.assistanceneed.decision.AssistanceLevel
+import fi.espoo.evaka.assistanceneed.decision.AssistanceNeedDecision
+import fi.espoo.evaka.assistanceneed.decision.AssistanceNeedDecisionChild
+import fi.espoo.evaka.assistanceneed.decision.AssistanceNeedDecisionEmployee
+import fi.espoo.evaka.assistanceneed.decision.AssistanceNeedDecisionLanguage
+import fi.espoo.evaka.assistanceneed.decision.AssistanceNeedDecisionMaker
+import fi.espoo.evaka.assistanceneed.decision.AssistanceNeedDecisionService
+import fi.espoo.evaka.assistanceneed.decision.AssistanceNeedDecisionStatus
+import fi.espoo.evaka.assistanceneed.decision.ServiceOptions
+import fi.espoo.evaka.assistanceneed.decision.StructuralMotivationOptions
+import fi.espoo.evaka.assistanceneed.decision.UnitInfo
+import fi.espoo.evaka.assistanceneed.preschooldecision.AssistanceNeedPreschoolDecision
+import fi.espoo.evaka.assistanceneed.preschooldecision.AssistanceNeedPreschoolDecisionChild
+import fi.espoo.evaka.assistanceneed.preschooldecision.AssistanceNeedPreschoolDecisionForm
+import fi.espoo.evaka.assistanceneed.preschooldecision.AssistanceNeedPreschoolDecisionGuardian
+import fi.espoo.evaka.assistanceneed.preschooldecision.AssistanceNeedPreschoolDecisionService
+import fi.espoo.evaka.assistanceneed.preschooldecision.AssistanceNeedPreschoolDecisionType
+import fi.espoo.evaka.decision.DecisionSendAddress
+import fi.espoo.evaka.identity.ExternalIdentifier
+import fi.espoo.evaka.invoicing.domain.PersonDetailed
+import fi.espoo.evaka.pis.service.PersonDTO
+import fi.espoo.evaka.shared.AssistanceNeedDecisionId
+import fi.espoo.evaka.shared.AssistanceNeedPreschoolDecisionGuardianId
+import fi.espoo.evaka.shared.AssistanceNeedPreschoolDecisionId
+import fi.espoo.evaka.shared.ChildId
+import fi.espoo.evaka.shared.DaycareId
+import fi.espoo.evaka.shared.EmployeeId
+import fi.espoo.evaka.shared.PersonId
+import fi.espoo.evaka.shared.domain.DateRange
+import fi.tampere.trevaka.AbstractIntegrationTest
+import fi.tampere.trevaka.reportsPath
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import java.io.FileOutputStream
+import java.time.LocalDate
+import java.util.UUID
+
+class PreschoolAssistanceNeedDecisionServiceTest : AbstractIntegrationTest() {
+
+    @Autowired
+    private lateinit var assistanceNeedDecisionService: AssistanceNeedPreschoolDecisionService
+
+    @Test
+    fun generatePdf() {
+        val headOfFamily = validPersonDTO
+
+        val bytes = assistanceNeedDecisionService.generatePdf(
+            sentDate = LocalDate.of(2022, 9, 12),
+            decision = validAssistanceNeedPreschoolDecision,
+            sendAddress = DecisionSendAddress.fromPerson(headOfFamily.toPersonDetailed()),
+            guardian = headOfFamily,
+            validTo = LocalDate.of(2022, 12, 31)
+        )
+
+        val filepath = "$reportsPath/PreschoolAssistanceNeedDecisionServiceTest-preschool-assistance-need-decision.pdf"
+        FileOutputStream(filepath).use { it.write(bytes) }
+    }
+
+    @Test
+    fun generatePdfWithoutGuardian() {
+        val bytes = assistanceNeedDecisionService.generatePdf(
+            sentDate = LocalDate.of(2022, 9, 12),
+            decision = validAssistanceNeedPreschoolDecision,
+            sendAddress = null,
+            guardian = null,
+            validTo = LocalDate.of(2022, 12, 31)
+        )
+
+        val filepath =
+            "$reportsPath/PreschoolAssistanceNeedDecisionServiceTest-preschool-assistance-need-decision-without-guardian.pdf"
+        FileOutputStream(filepath).use { it.write(bytes) }
+    }
+
+    @Test
+    fun generatePdfWithPreparedBy() {
+        val decision = validAssistanceNeedDecision.copy(
+            preparedBy1 = AssistanceNeedDecisionEmployee(
+                employeeId = EmployeeId(UUID.randomUUID()),
+                title = "Palvelupäällikkö",
+                name = "Vallu Valmistelija",
+                phoneNumber = "0501234567",
+            ),
+            preparedBy2 = AssistanceNeedDecisionEmployee(
+                employeeId = EmployeeId(UUID.randomUUID()),
+                title = "Palvelupäällikkö",
+                name = "Valle Valmistelija",
+                phoneNumber = "0507654321",
+            ),
+        )
+        val headOfFamily = validPersonDTO
+
+        val bytes = assistanceNeedDecisionService.generatePdf(
+            sentDate = LocalDate.of(2022, 9, 12),
+            decision = validAssistanceNeedPreschoolDecision,
+            sendAddress = DecisionSendAddress.fromPerson(headOfFamily.toPersonDetailed2()),
+            guardian = headOfFamily,
+            validTo = LocalDate.of(2022, 12, 31)
+        )
+
+        val filepath =
+            "$reportsPath/PreschoolAssistanceNeedDecisionServiceTest-preschool-assistance-need-decision-with-prepared-by.pdf"
+        FileOutputStream(filepath).use { it.write(bytes) }
+    }
+
+    @Test
+    fun generatePdfWithEmptyPreparedBy() {
+        val preparedBy = AssistanceNeedDecisionEmployee(
+            employeeId = null,
+            title = null,
+            name = null,
+            phoneNumber = null,
+        )
+        val decision = validAssistanceNeedDecision.copy(
+            preparedBy1 = preparedBy,
+            preparedBy2 = preparedBy,
+        )
+        val headOfFamily = validPersonDTO
+
+        val bytes = assistanceNeedDecisionService.generatePdf(
+            sentDate = LocalDate.of(2022, 9, 12),
+            decision = validAssistanceNeedPreschoolDecision,
+            sendAddress = DecisionSendAddress.fromPerson(headOfFamily.toPersonDetailed2()),
+            guardian = headOfFamily,
+            validTo = LocalDate.of(2022, 12, 31)
+        )
+
+        val filepath =
+            "$reportsPath/PreschoolAssistanceNeedDecisionServiceTest-preschool-assistance-need-decision-with-empty-prepared-by.pdf"
+        FileOutputStream(filepath).use { it.write(bytes) }
+    }
+}
+
+private val validAssistanceNeedDecision = AssistanceNeedDecision(
+    id = AssistanceNeedDecisionId(UUID.randomUUID()),
+    decisionNumber = 125632424,
+    child = AssistanceNeedDecisionChild(
+        id = ChildId(UUID.randomUUID()),
+        name = "Matti Meikäläinen",
+        dateOfBirth = LocalDate.of(2020, 1, 5),
+    ),
+    validityPeriod = DateRange(LocalDate.of(2022, 8, 2), LocalDate.of(2022, 12, 31)),
+    status = AssistanceNeedDecisionStatus.ACCEPTED,
+    language = AssistanceNeedDecisionLanguage.FI,
+    decisionMade = LocalDate.of(2022, 7, 1),
+    sentForDecision = LocalDate.of(2022, 5, 12),
+    selectedUnit = UnitInfo(
+        id = DaycareId(UUID.randomUUID()),
+        name = "Amurin päiväkoti",
+        streetAddress = "Amurinpolku 1",
+        postalCode = "33100",
+        postOffice = "Tampere",
+    ),
+    preparedBy1 = null,
+    preparedBy2 = null,
+    decisionMaker = AssistanceNeedDecisionMaker(
+        employeeId = EmployeeId(UUID.randomUUID()),
+        title = "Asiakaspalvelupäällikkö",
+        name = "Paula Palvelupäällikkö",
+    ),
+    pedagogicalMotivation = null,
+    structuralMotivationOptions = StructuralMotivationOptions(
+        smallerGroup = false,
+        specialGroup = false,
+        smallGroup = false,
+        groupAssistant = false,
+        childAssistant = false,
+        additionalStaff = false,
+    ),
+    structuralMotivationDescription = null,
+    careMotivation = null,
+    serviceOptions = ServiceOptions(
+        consultationSpecialEd = false,
+        partTimeSpecialEd = false,
+        fullTimeSpecialEd = false,
+        interpretationAndAssistanceServices = false,
+        specialAides = false,
+    ),
+    servicesMotivation = null,
+    expertResponsibilities = null,
+    guardiansHeardOn = null,
+    guardianInfo = emptySet(),
+    viewOfGuardians = null,
+    otherRepresentativeHeard = false,
+    otherRepresentativeDetails = null,
+    assistanceLevels = setOf(AssistanceLevel.ENHANCED_ASSISTANCE),
+    motivationForDecision = null,
+    annulmentReason = "",
+    hasDocument = false,
+)
+
+private val validAssistanceNeedPreschoolDecisionForm =
+    AssistanceNeedPreschoolDecisionForm(
+        language = AssistanceNeedDecisionLanguage.FI,
+        type = AssistanceNeedPreschoolDecisionType.NEW,
+        validFrom = LocalDate.of(2022, 8, 2),
+        extendedCompulsoryEducation = true,
+        extendedCompulsoryEducationInfo = "This is the extended compulsory education info content",
+        grantedAssistanceService = true,
+        grantedInterpretationService = true,
+        grantedAssistiveDevices = true,
+        grantedServicesBasis = "This is the granted services basis content",
+        selectedUnit = DaycareId(UUID.randomUUID()),
+        primaryGroup = "Ensisijainen ryhmä tähän",
+        decisionBasis = "Päätöksentekoperuste tähän",
+        basisDocumentPedagogicalReport = true,
+        basisDocumentPsychologistStatement = true,
+        basisDocumentSocialReport = true,
+        basisDocumentDoctorStatement = true,
+        basisDocumentOtherOrMissing = true,
+        basisDocumentOtherOrMissingInfo = "This is the basis document other or missing info content",
+        basisDocumentsInfo = "This is the basis documents info content",
+        guardiansHeardOn = LocalDate.of(2022, 8, 2),
+        guardianInfo =
+        setOf(
+            AssistanceNeedPreschoolDecisionGuardian(
+                id = AssistanceNeedPreschoolDecisionGuardianId(UUID.randomUUID()),
+                personId = PersonId(UUID.randomUUID()),
+                name = "Testaaja Huoltaja",
+                isHeard = true,
+                details = "Huoltajayksityiskohtia tähän"
+            )
+        ),
+        otherRepresentativeHeard = false,
+        otherRepresentativeDetails = "",
+        viewOfGuardians = "Huoltajien näkemys tähän",
+        preparer1EmployeeId = EmployeeId(UUID.randomUUID()),
+        preparer1Title = "worker",
+        preparer1PhoneNumber = "01020405060",
+        preparer2EmployeeId = null,
+        preparer2Title = "",
+        preparer2PhoneNumber = "",
+        decisionMakerEmployeeId = EmployeeId(UUID.randomUUID()),
+        decisionMakerTitle = "Päätöksen tekijän titteli"
+    )
+
+private val validAssistanceNeedPreschoolDecision = AssistanceNeedPreschoolDecision(
+    id = AssistanceNeedPreschoolDecisionId(UUID.randomUUID()),
+    decisionNumber = 125632424,
+    child = AssistanceNeedPreschoolDecisionChild(
+        id = ChildId(UUID.randomUUID()),
+        name = "Matti Meikäläinen",
+        dateOfBirth = LocalDate.of(2020, 1, 5),
+    ),
+    status = AssistanceNeedDecisionStatus.ACCEPTED,
+    form = validAssistanceNeedPreschoolDecisionForm,
+    decisionMade = LocalDate.of(2022, 7, 1),
+    sentForDecision = LocalDate.of(2022, 5, 12),
+    annulmentReason = "",
+    hasDocument = false,
+    decisionMakerHasOpened = true,
+    decisionMakerName = "Make Maker",
+    preparer1Name = "Valmistelija 1",
+    preparer2Name = "Valmistelija 2",
+    unitName = "Kelokujan lapsiparkki",
+    unitPostalCode = "22222",
+    unitPostOffice = "Parkkila",
+    unitStreetAddress = "Kelokuja 122 G"
+)
+
+private val validPersonDTO = PersonDTO(
+    id = PersonId(UUID.randomUUID()),
+    identity = ExternalIdentifier.SSN.getInstance("310382-956D"),
+    ssnAddingDisabled = false,
+    firstName = "Maija",
+    lastName = "Meikäläinen",
+    preferredName = "Maija",
+    email = null,
+    phone = "",
+    backupPhone = "",
+    language = null,
+    dateOfBirth = LocalDate.of(1982, 3, 31),
+    dateOfDeath = null,
+    streetAddress = "Meikäläisenkuja 6 B 7",
+    postalCode = "33730",
+    postOffice = "TAMPERE",
+    residenceCode = "",
+)
+
+fun PersonDTO.toPersonDetailed2() = PersonDetailed(
+    id = this.id,
+    dateOfBirth = this.dateOfBirth,
+    dateOfDeath = this.dateOfDeath,
+    firstName = this.firstName,
+    lastName = this.lastName,
+    ssn = this.identity.let {
+        when (it) {
+            is ExternalIdentifier.SSN -> it.toString()
+            is ExternalIdentifier.NoID -> null
+        }
+    },
+    streetAddress = this.streetAddress,
+    postalCode = this.postalCode,
+    postOffice = this.postOffice,
+    residenceCode = this.residenceCode,
+    email = this.email,
+    phone = this.phone,
+    language = this.language,
+    invoiceRecipientName = this.invoiceRecipientName,
+    invoicingStreetAddress = this.invoicingStreetAddress,
+    invoicingPostalCode = this.invoicingPostalCode,
+    invoicingPostOffice = this.invoicingPostOffice,
+    restrictedDetailsEnabled = this.restrictedDetailsEnabled,
+    forceManualFeeDecisions = this.forceManualFeeDecisions,
+)


### PR DESCRIPTION
New stuff:
- new template for preschool assistance need decision PDF generation
- new properties file for above template texts
- new integration test for above PDF generation with "valid" test data

Updated stuff:
- employee translations
  -  added Tampere-specific info text content for the draft decision editing view
  -  new appeal instructions for preschool assistance need decisions in employee UI
- citizen translations
  - new appeal instructions for preschool assistance decisions in citizen UI
- early education assistance need decision template properties
  - fixed the missing spaces issue in appeal instructions