### PR TITLE
Remove hard-coded service profile

### DIFF
--- a/service/build.gradle.kts
+++ b/service/build.gradle.kts
@@ -57,7 +57,7 @@ dependencies {
 }
 
 springBoot {
-    mainClass.set("fi.tampere.trevaka.TrevakaMainKt")
+    mainClass.set("trevaka.MainKt")
 }
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
@@ -73,7 +73,7 @@ tasks {
         systemProperty("spring.profiles.active", "integration-test,trevaka")
     }
     bootRun {
-        systemProperty("spring.profiles.active", "local,trevaka-local")
+        systemProperty("spring.profiles.active", "local,trevaka,trevaka-local")
     }
 }
 

--- a/service/src/main/kotlin/fi/tampere/trevaka/emailclient/config/EmailConfiguration.kt
+++ b/service/src/main/kotlin/fi/tampere/trevaka/emailclient/config/EmailConfiguration.kt
@@ -17,12 +17,10 @@ import fi.espoo.evaka.shared.MessageThreadId
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.context.annotation.Profile
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
 import java.util.Locale
 
-@Profile("trevaka")
 @Configuration
 class EmailConfiguration {
 

--- a/service/src/main/kotlin/fi/tampere/trevaka/invoice/config/InvoiceConfiguration.kt
+++ b/service/src/main/kotlin/fi/tampere/trevaka/invoice/config/InvoiceConfiguration.kt
@@ -27,7 +27,6 @@ import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Primary
-import org.springframework.context.annotation.Profile
 import org.springframework.oxm.jaxb.Jaxb2Marshaller
 import org.springframework.ws.client.core.WebServiceTemplate
 import org.springframework.ws.soap.SoapVersion
@@ -45,7 +44,6 @@ internal val SOAP_PACKAGES = arrayOf(
     "fi.tampere.services.sapsd.salesorder.v1",
 )
 
-@Profile("trevaka")
 @Configuration
 class InvoiceConfiguration {
     @Primary

--- a/service/src/main/kotlin/fi/tampere/trevaka/titania/TitaniaController.kt
+++ b/service/src/main/kotlin/fi/tampere/trevaka/titania/TitaniaController.kt
@@ -10,11 +10,8 @@ import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.Forbidden
 import jakarta.servlet.http.HttpServletRequest
 import mu.KotlinLogging
-import org.springframework.core.Ordered
-import org.springframework.core.annotation.Order
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
@@ -47,11 +44,6 @@ class TitaniaController(private val titaniaService: TitaniaService) {
         if (user.type != AuthenticatedUserType.integration) throw Forbidden()
         return db.connect { dbc -> dbc.read { tx -> titaniaService.getStampedWorkingTimeEvents(tx, request) } }
     }
-}
-
-@Order(Ordered.HIGHEST_PRECEDENCE)
-@ControllerAdvice
-class TitaniaExceptionHandlers() {
 
     @ExceptionHandler(TitaniaException::class)
     fun titaniaExceptionHandler(ex: TitaniaException, req: HttpServletRequest): ResponseEntity<TitaniaErrorResponse> {

--- a/service/src/main/kotlin/trevaka/Main.kt
+++ b/service/src/main/kotlin/trevaka/Main.kt
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-package fi.tampere.trevaka
+package trevaka
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration
@@ -10,11 +10,10 @@ import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration
 import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration
 import org.springframework.boot.autoconfigure.transaction.TransactionAutoConfiguration
-import org.springframework.boot.builder.SpringApplicationBuilder
-import org.springframework.boot.context.properties.ConfigurationPropertiesScan
+import org.springframework.boot.runApplication
 
 @SpringBootApplication(
-    scanBasePackages = ["fi.tampere.trevaka", "fi.espoo.evaka"],
+    scanBasePackages = ["trevaka", "fi.espoo.evaka"],
     exclude = [
         DataSourceAutoConfiguration::class,
         FlywayAutoConfiguration::class,
@@ -23,12 +22,8 @@ import org.springframework.boot.context.properties.ConfigurationPropertiesScan
         TransactionAutoConfiguration::class,
     ],
 )
-@ConfigurationPropertiesScan(basePackages = ["fi.tampere.trevaka"])
-class TrevakaMain
+class Main
 
 fun main(args: Array<String>) {
-    SpringApplicationBuilder()
-        .sources(TrevakaMain::class.java)
-        .profiles("trevaka")
-        .run(*args)
+    runApplication<Main>(*args)
 }

--- a/service/src/main/kotlin/trevaka/TampereComponentScan.kt
+++ b/service/src/main/kotlin/trevaka/TampereComponentScan.kt
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2021-2023 City of Tampere
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package trevaka
+
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
+
+@Profile("trevaka")
+@Configuration
+@ComponentScan("fi.tampere.trevaka")
+@ConfigurationPropertiesScan(basePackages = ["fi.tampere.trevaka"])
+class TampereComponentScan

--- a/service/src/test/kotlin/fi/tampere/trevaka/AbstractIntegrationTest.kt
+++ b/service/src/test/kotlin/fi/tampere/trevaka/AbstractIntegrationTest.kt
@@ -21,6 +21,7 @@ import org.springframework.boot.test.web.server.LocalServerPort
 import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock
 import org.springframework.core.io.Resource
 import org.springframework.util.StreamUtils
+import trevaka.Main
 import java.nio.charset.Charset
 import java.nio.charset.StandardCharsets
 import java.nio.file.Paths
@@ -31,7 +32,7 @@ val reportsPath: String = "${Paths.get("build").toAbsolutePath()}/reports"
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @SpringBootTest(
     webEnvironment = WebEnvironment.RANDOM_PORT,
-    classes = [IntegrationTestConfiguration::class],
+    classes = [Main::class, IntegrationTestConfiguration::class],
 )
 @AutoConfigureWireMock(port = 0)
 abstract class AbstractIntegrationTest(private val resetDbBeforeEach: Boolean = true) {


### PR DESCRIPTION
This allows us to use service for multiple municipalities.

There are still some hard-coded values in `build.gradle.kts` but this is already a good start.