### PR TITLE
TREV-1199 - Hide settings menu from 2nd & 3rd wave (except ylöjärvi)

### DIFF
--- a/service/src/main/kotlin/fi/ylojarvi/evaka/security/YlojarviActionRuleMapping.kt
+++ b/service/src/main/kotlin/fi/ylojarvi/evaka/security/YlojarviActionRuleMapping.kt
@@ -73,7 +73,10 @@ class YlojarviActionRuleMapping : ActionRuleMapping {
             )
         }
         Action.Global.SEND_PATU_REPORT, Action.Global.SUBMIT_PATU_REPORT -> emptySequence()
-        Action.Global.SETTINGS_PAGE, Action.Global.UPDATE_SETTINGS -> emptySequence()
+        Action.Global.SETTINGS_PAGE,
+        Action.Global.UPDATE_SETTINGS,
+        ->
+            action.defaultRules.asSequence() + sequenceOf(HasGlobalRole(UserRole.SERVICE_WORKER))
         else -> action.defaultRules.asSequence()
     }
 


### PR DESCRIPTION
https://voltti.atlassian.net/browse/TREV-1199

Enabled access to settings in Ylöjärvi, others were already hidden