### PR TITLE
Standardizing income statement instructions in decision PDFs across municipalities

### DIFF
--- a/service/src/main/resources/WEB-INF/templates/hameenkyro/daycare/decision.properties
+++ b/service/src/main/resources/WEB-INF/templates/hameenkyro/daycare/decision.properties
@@ -22,8 +22,9 @@ decision.instructions=\
   <p>Lapsen tulee aloittaa varhaiskasvatuksessa kahden viikon kuluessa ilmoitetusta aloittamispäivästä, muutoin päätös varhaiskasvatukseen ottamisesta raukeaa. \
   Varhaiskasvatuksen aloitusta voidaan siirtää enintään kaksi viikkoa eteenpäin hakemuksessa ilmoitetusta aloituspäivämäärästä alkaen.</p> \
   <p>Varhaiskasvatuksen asiakasmaksu alkaa siitä päivästä lukien, minkä olette vahvistaneet alkamispäiväksi. \
-  Uusien asiakkaiden tulee tehdä tuloselvitys maksun määrittämiseksi tai antaa suostumus korkeimpaan asiakasmaksuun varhaiskasvatuksen aloittamiskuukauden aikana. \
-  Mikäli tuloselvitystä ei toimiteta Varhaiskasvatuksen asiakasmaksuihin määräaikaan mennessä, peritään korkein asiakasmaksu (Laki varhaiskasvatuksen asiakasmaksuista 5 §).</p>\
+  Uusien asiakkaiden tulee toimittaa perheen tulotiedot maksun määräämiseksi tai antaa suostumus korkeimpaan asiakasmaksuun kuukauden kuluessa varhaiskasvatuksen aloittamisesta. \
+  Mikäli tulotietoja ei toimiteta asiakasmaksuihin määräaikaan mennessä, voidaan periä korkein asiakasmaksu (Laki varhaiskasvatuksen asiakasmaksuista § 5).</p>\
+  <p>Selvitys perheen tuloista annetaan varhaiskasvatuksen verkkopalvelun kautta tuloselvityslomakkeella.</p>\
   <h2>Asiakasmaksuihin liittyvät ohjeet ja lomakkeet:</h2>\
   <p><a href="https://hameenkyro.fi/palvelut/kasvatus-ja-opetus/varhaiskasvatus/asiakasmaksut/ ">https://hameenkyro.fi/palvelut/kasvatus-ja-opetus/varhaiskasvatus/asiakasmaksut/ </a></p> \
   <p>Kotihoidon tai yksityisen hoidon tuen saajan on ilmoitettava viipymättä Kelaan varhaiskasvatuksen alkamisesta.</p>
@@ -42,7 +43,8 @@ decision.instructions.PRESCHOOL_DAYCARE=\
   Mikäli kieltäydytte paikasta ja lapselle haetaan uutta täydentävän toiminnan paikkaa, on se tehtävä uudella hakemuksella. </p> \
   <p>Jos lapsi ei aloita vastaanottamassanne paikassa, eikä paikkaa ole peruttu ennen ilmoituksenne mukaista alkamisajankohtaa, teiltä peritään puolet kuukausimaksusta.</p> \
   <p>Esiopetusta täydentävä varhaiskasvatus<br/> \
-  Asiakasmaksu määräytyy huoltajien bruttotulojen perusteella varhaiskasvatuksen asiakasmaksulain mukaisesti. Huoltajien tulee tehdä tuloselvitys maksun määrittämiseksi tai heidän tulee antaa suostumus korkeimpaan asiakasmaksuun täydentävän varhaiskasvatuksen aloittamiskuukauden aikana. Mikäli tuloselvitystä ei toimiteta Varhaiskasvatuksen asiakasmaksuihin määräaikaan mennessä, peritään korkein asiakasmaksu (Laki varhaiskasvatuksen asiakasmaksuista 5 §).</p> \
+  Asiakasmaksu määräytyy huoltajien bruttotulojen perusteella varhaiskasvatuksen asiakasmaksulain mukaisesti. Uusien asiakkaiden tulee toimittaa perheen tulotiedot maksun määräämiseksi tai antaa suostumus korkeimpaan asiakasmaksuun kuukauden kuluessa varhaiskasvatuksen aloittamisesta. Mikäli tulotietoja ei toimiteta asiakasmaksuihin määräaikaan mennessä, voidaan periä korkein asiakasmaksu (Laki varhaiskasvatuksen asiakasmaksuista § 5).</p> \
+  <p>Selvitys perheen tuloista annetaan varhaiskasvatuksen verkkopalvelun kautta tuloselvityslomakkeella.</p>\
   <p>Esiopetuksen kerhot<br/> \
   Esiopetuksen kerhotoiminnassa on kiinteä kuukausimaksu, valitun palveluntarpeen mukaan. \
   Maksuista voi hakea maksuvapautusta varhaiskasvatuksen maksurajojen mukaisesti.</p> \
@@ -57,7 +59,9 @@ decision.instructions.PRESCHOOL_CLUB=\
   Mikäli kieltäydytte paikasta ja lapselle haetaan uutta täydentävän toiminnan paikkaa, on se tehtävä uudella hakemuksella. </p> \
   <p>Jos lapsi ei aloita vastaanottamassanne paikassa, eikä paikkaa ole peruttu ennen ilmoituksenne mukaista alkamisajankohtaa, teiltä peritään puolet kuukausimaksusta.</p> \
   <p>Esiopetusta täydentävä varhaiskasvatus<br/> \
-  Asiakasmaksu määräytyy huoltajien bruttotulojen perusteella varhaiskasvatuksen asiakasmaksulain mukaisesti. Huoltajien tulee tehdä tuloselvitys maksun määrittämiseksi tai heidän tulee antaa suostumus korkeimpaan asiakasmaksuun täydentävän varhaiskasvatuksen aloittamiskuukauden aikana. Mikäli tuloselvitystä ei toimiteta Varhaiskasvatuksen asiakasmaksuihin määräaikaan mennessä, peritään korkein asiakasmaksu (Laki varhaiskasvatuksen asiakasmaksuista 5 §).</p> \
+  Asiakasmaksu määräytyy huoltajien bruttotulojen perusteella varhaiskasvatuksen asiakasmaksulain mukaisesti. Uusien asiakkaiden tulee toimittaa perheen tulotiedot maksun määräämiseksi tai antaa suostumus korkeimpaan asiakasmaksuun kuukauden kuluessa varhaiskasvatuksen aloittamisesta. \
+  Mikäli tulotietoja ei toimiteta asiakasmaksuihin määräaikaan mennessä, voidaan periä korkein asiakasmaksu (Laki varhaiskasvatuksen asiakasmaksuista § 5).</p>\
+  <p>Selvitys perheen tuloista annetaan varhaiskasvatuksen verkkopalvelun kautta tuloselvityslomakkeella.</p>\
   <p>Esiopetuksen kerhot<br/> \
   Esiopetuksen kerhotoiminnassa on kiinteä kuukausimaksu, valitun palveluntarpeen mukaan. \
   Maksuista voi hakea maksuvapautusta varhaiskasvatuksen maksurajojen mukaisesti.</p> \

--- a/service/src/main/resources/WEB-INF/templates/hameenkyro/daycare/voucher/decision.properties
+++ b/service/src/main/resources/WEB-INF/templates/hameenkyro/daycare/voucher/decision.properties
@@ -16,7 +16,9 @@ decision.instructions=\
   <h2>Sovelletut oikeusohjeet</h2><p>Varhaiskasvatuslaki</p>\
   <p>Tämä päätös poistaa lapsen varhaiskasvatushakemuksen. Mikäli kieltäydytte lapsikohtaisesta varhaiskasvatuksen palvelusetelistä ja lapselle haetaan uutta varhaiskasvatuspaikkaa, on se tehtävä uudella hakemuksella.</p>
 decision.legalInstructions=\
-  <p>Palvelusetelin arvosta tehdään erillinen päätös. Uusien asiakkaiden tulee toimittaa asiakasmaksulomake omavastuuosuuden määrittämiseksi tai antaa suostumus korkeimpaan asiakasmaksuun kuukauden kuluessa varhaiskasvatuksen aloittamisesta. Mikäli asiakasmaksulomaketta ei toimiteta Varhaiskasvatuksen ja esiopetuksen asiakasmaksuihin määräaikaan mennessä, peritään korkein omavastuuosuus (Laki varhaiskasvatuksen asiakasmaksuista 5 §). Palvelusetelipaikasta irtisanoutumisaika on yksi kuukausi.</p>\
+  <p>Palvelusetelin arvosta tehdään erillinen päätös. Uusien asiakkaiden tulee toimittaa perheen tulotiedot maksun määräämiseksi tai antaa suostumus korkeimpaan asiakasmaksuun kuukauden kuluessa varhaiskasvatuksen aloittamisesta. Mikäli tulotietoja ei toimiteta asiakasmaksuihin määräaikaan mennessä, voidaan periä korkein asiakasmaksu (Laki varhaiskasvatuksen asiakasmaksuista § 5).</p>\
+  <p>Selvitys perheen tuloista annetaan varhaiskasvatuksen verkkopalvelun kautta tuloselvityslomakkeella.</p> \
+  <p>Palvelusetelipaikasta irtisanoutumisaika on yksi kuukausi.</p>\
   <h2>Asiakasmaksuihin liittyvät ohjeet ja lomakkeet:</h2>\
   <p><a href="https://hameenkyro.fi/palvelut/kasvatus-ja-opetus/varhaiskasvatus/asiakasmaksut/">https://hameenkyro.fi/palvelut/kasvatus-ja-opetus/varhaiskasvatus/asiakasmaksut/</a></p>\
   <p>Kotihoidon tai yksityisen hoidon tuen saajan on ilmoitettava viipymättä Kelaan varhaiskasvatuksen alkamisesta.</p>

--- a/service/src/main/resources/WEB-INF/templates/kangasala/daycare/decision.properties
+++ b/service/src/main/resources/WEB-INF/templates/kangasala/daycare/decision.properties
@@ -22,8 +22,9 @@ decision.instructions=\
   <p>Lapsen tulee aloittaa varhaiskasvatuksessa kahden viikon kuluessa ilmoitetusta aloittamispäivästä, muutoin päätös varhaiskasvatukseen ottamisesta raukeaa. \
   Varhaiskasvatuksen aloitusta voidaan siirtää enintään kaksi viikkoa eteenpäin hakemuksessa ilmoitetusta aloituspäivämäärästä alkaen.</p> \
   <p>Varhaiskasvatuksen asiakasmaksu alkaa siitä päivästä lukien, minkä olette vahvistaneet alkamispäiväksi. \
-  Uusien asiakkaiden tulee tehdä tuloselvitys maksun määrittämiseksi tai antaa suostumus korkeimpaan asiakasmaksuun varhaiskasvatuksen aloittamiskuukauden aikana. \
-  Mikäli tuloselvitystä ei toimiteta Varhaiskasvatuksen asiakasmaksuihin määräaikaan mennessä, peritään korkein asiakasmaksu (Laki varhaiskasvatuksen asiakasmaksuista 5 §).</p>\
+  Uusien asiakkaiden tulee toimittaa perheen tulotiedot maksun määräämiseksi tai antaa suostumus korkeimpaan asiakasmaksuun kuukauden kuluessa varhaiskasvatuksen aloittamisesta. \
+  Mikäli tulotietoja ei toimiteta asiakasmaksuihin määräaikaan mennessä, voidaan periä korkein asiakasmaksu (Laki varhaiskasvatuksen asiakasmaksuista § 5).</p>\
+  <p>Selvitys perheen tuloista annetaan varhaiskasvatuksen verkkopalvelun kautta tuloselvityslomakkeella.</p>\
   <h2>Asiakasmaksuihin liittyvät ohjeet ja lomakkeet:</h2>\
   <p><a href="https://www.kangasala.fi/varhaiskasvatus-ja-opetus/varhaiskasvatus/varhaiskasvatuksen-maksut-ja-tuet/ ">https://www.kangasala.fi/varhaiskasvatus-ja-opetus/varhaiskasvatus/varhaiskasvatuksen-maksut-ja-tuet/ </a></p> \
   <p>Kotihoidon tai yksityisen hoidon tuen saajan on ilmoitettava viipymättä Kelaan varhaiskasvatuksen alkamisesta.</p>
@@ -42,7 +43,9 @@ decision.instructions.PRESCHOOL_DAYCARE=\
   Mikäli kieltäydytte paikasta ja lapselle haetaan uutta täydentävän toiminnan paikkaa, on se tehtävä uudella hakemuksella. </p> \
   <p>Jos lapsi ei aloita vastaanottamassanne paikassa, eikä paikkaa ole peruttu ennen ilmoituksenne mukaista alkamisajankohtaa, teiltä peritään puolet kuukausimaksusta.</p> \
   <p>Esiopetusta täydentävä varhaiskasvatus<br/> \
-  Asiakasmaksu määräytyy huoltajien bruttotulojen perusteella varhaiskasvatuksen asiakasmaksulain mukaisesti. Huoltajien tulee tehdä tuloselvitys maksun määrittämiseksi tai heidän tulee antaa suostumus korkeimpaan asiakasmaksuun täydentävän varhaiskasvatuksen aloittamiskuukauden aikana. Mikäli tuloselvitystä ei toimiteta Varhaiskasvatuksen asiakasmaksuihin määräaikaan mennessä, peritään korkein asiakasmaksu (Laki varhaiskasvatuksen asiakasmaksuista 5 §).</p> \
+  Asiakasmaksu määräytyy huoltajien bruttotulojen perusteella varhaiskasvatuksen asiakasmaksulain mukaisesti. Uusien asiakkaiden tulee toimittaa perheen tulotiedot maksun määräämiseksi tai antaa suostumus korkeimpaan asiakasmaksuun kuukauden kuluessa varhaiskasvatuksen aloittamisesta. \
+  Mikäli tulotietoja ei toimiteta asiakasmaksuihin määräaikaan mennessä, voidaan periä korkein asiakasmaksu (Laki varhaiskasvatuksen asiakasmaksuista § 5).</p>\
+  <p>Selvitys perheen tuloista annetaan varhaiskasvatuksen verkkopalvelun kautta tuloselvityslomakkeella.</p>\
   <p>Esiopetuksen kerhot<br/> \
   Esiopetuksen kerhotoiminnassa on kiinteä kuukausimaksu, valitun palveluntarpeen mukaan. \
   Maksuista voi hakea maksuvapautusta varhaiskasvatuksen maksurajojen mukaisesti.</p> \
@@ -57,7 +60,9 @@ decision.instructions.PRESCHOOL_CLUB=\
   Mikäli kieltäydytte paikasta ja lapselle haetaan uutta täydentävän toiminnan paikkaa, on se tehtävä uudella hakemuksella. </p> \
   <p>Jos lapsi ei aloita vastaanottamassanne paikassa, eikä paikkaa ole peruttu ennen ilmoituksenne mukaista alkamisajankohtaa, teiltä peritään puolet kuukausimaksusta.</p> \
   <p>Esiopetusta täydentävä varhaiskasvatus<br/> \
-  Asiakasmaksu määräytyy huoltajien bruttotulojen perusteella varhaiskasvatuksen asiakasmaksulain mukaisesti. Huoltajien tulee tehdä tuloselvitys maksun määrittämiseksi tai heidän tulee antaa suostumus korkeimpaan asiakasmaksuun täydentävän varhaiskasvatuksen aloittamiskuukauden aikana. Mikäli tuloselvitystä ei toimiteta Varhaiskasvatuksen asiakasmaksuihin määräaikaan mennessä, peritään korkein asiakasmaksu (Laki varhaiskasvatuksen asiakasmaksuista 5 §).</p> \
+  Asiakasmaksu määräytyy huoltajien bruttotulojen perusteella varhaiskasvatuksen asiakasmaksulain mukaisesti. Uusien asiakkaiden tulee toimittaa perheen tulotiedot maksun määräämiseksi tai antaa suostumus korkeimpaan asiakasmaksuun kuukauden kuluessa varhaiskasvatuksen aloittamisesta. \
+  Mikäli tulotietoja ei toimiteta asiakasmaksuihin määräaikaan mennessä, voidaan periä korkein asiakasmaksu (Laki varhaiskasvatuksen asiakasmaksuista § 5).</p>\
+  <p>Selvitys perheen tuloista annetaan varhaiskasvatuksen verkkopalvelun kautta tuloselvityslomakkeella.</p>\
   <p>Esiopetuksen kerhot<br/> \
   Esiopetuksen kerhotoiminnassa on kiinteä kuukausimaksu, valitun palveluntarpeen mukaan. \
   Maksuista voi hakea maksuvapautusta varhaiskasvatuksen maksurajojen mukaisesti.</p> \

--- a/service/src/main/resources/WEB-INF/templates/kangasala/daycare/voucher/decision.properties
+++ b/service/src/main/resources/WEB-INF/templates/kangasala/daycare/voucher/decision.properties
@@ -16,7 +16,9 @@ decision.instructions=\
   <h2>Sovelletut oikeusohjeet</h2><p>Varhaiskasvatuslaki</p>\
   <p>Tämä päätös poistaa lapsen varhaiskasvatushakemuksen. Mikäli kieltäydytte lapsikohtaisesta varhaiskasvatuksen palvelusetelistä ja lapselle haetaan uutta varhaiskasvatuspaikkaa, on se tehtävä uudella hakemuksella.</p>
 decision.legalInstructions=\
-  <p>Palvelusetelin arvosta tehdään erillinen päätös. Uusien asiakkaiden tulee toimittaa asiakasmaksulomake omavastuuosuuden määrittämiseksi tai antaa suostumus korkeimpaan asiakasmaksuun kuukauden kuluessa varhaiskasvatuksen aloittamisesta. Mikäli asiakasmaksulomaketta ei toimiteta Varhaiskasvatuksen ja esiopetuksen asiakasmaksuihin määräaikaan mennessä, peritään korkein omavastuuosuus (Laki varhaiskasvatuksen asiakasmaksuista 5 §). Palvelusetelipaikasta irtisanoutumisaika on yksi kuukausi.</p>\
+  <p>Palvelusetelin arvosta tehdään erillinen päätös. Uusien asiakkaiden tulee toimittaa perheen tulotiedot maksun määräämiseksi tai antaa suostumus korkeimpaan asiakasmaksuun kuukauden kuluessa varhaiskasvatuksen aloittamisesta. Mikäli tulotietoja ei toimiteta asiakasmaksuihin määräaikaan mennessä, voidaan periä korkein asiakasmaksu (Laki varhaiskasvatuksen asiakasmaksuista § 5).</p>\
+  <p>Selvitys perheen tuloista annetaan varhaiskasvatuksen verkkopalvelun kautta tuloselvityslomakkeella.</p> \
+  <p>Palvelusetelipaikasta irtisanoutumisaika on yksi kuukausi.</p>\
   <h2>Asiakasmaksuihin liittyvät ohjeet ja lomakkeet:</h2>\
   <p><a href="https://www.kangasala.fi/varhaiskasvatus-ja-opetus/varhaiskasvatus/varhaiskasvatuksen-maksut-ja-tuet/">https://www.kangasala.fi/varhaiskasvatus-ja-opetus/varhaiskasvatus/varhaiskasvatuksen-maksut-ja-tuet/</a></p>\
   <p>Kotihoidon tai yksityisen hoidon tuen saajan on ilmoitettava viipymättä Kelaan varhaiskasvatuksen alkamisesta.</p>

--- a/service/src/main/resources/WEB-INF/templates/lempaala/daycare/decision.properties
+++ b/service/src/main/resources/WEB-INF/templates/lempaala/daycare/decision.properties
@@ -22,8 +22,9 @@ decision.instructions=\
   <p>Lapsen tulee aloittaa varhaiskasvatuksessa kahden viikon kuluessa ilmoitetusta aloittamispäivästä, muutoin päätös varhaiskasvatukseen ottamisesta raukeaa. \
   Varhaiskasvatuksen aloitusta voidaan siirtää enintään kaksi viikkoa eteenpäin hakemuksessa ilmoitetusta aloituspäivämäärästä alkaen.</p> \
   <p>Varhaiskasvatuksen asiakasmaksu alkaa siitä päivästä lukien, minkä olette vahvistaneet alkamispäiväksi. \
-  Uusien asiakkaiden tulee tehdä tuloselvitys maksun määrittämiseksi tai antaa suostumus korkeimpaan asiakasmaksuun varhaiskasvatuksen aloittamiskuukauden aikana. \
-  Mikäli tuloselvitystä ei toimiteta, peritään korkein asiakasmaksu (Laki varhaiskasvatuksen asiakasmaksuista 5 §).</p>\
+  Uusien asiakkaiden tulee toimittaa perheen tulotiedot maksun määräämiseksi tai antaa suostumus korkeimpaan asiakasmaksuun kuukauden kuluessa varhaiskasvatuksen aloittamisesta. \
+  Mikäli tulotietoja ei toimiteta asiakasmaksuihin määräaikaan mennessä, voidaan periä korkein asiakasmaksu (Laki varhaiskasvatuksen asiakasmaksuista § 5).</p>\
+  <p>Selvitys perheen tuloista annetaan varhaiskasvatuksen verkkopalvelun kautta tuloselvityslomakkeella.</p>\
   <p>Hoidon aloitukseen liittyvä Tervetuloa-paketti löytyy varhaiskasvatuksen nettisivuilta. Paketti sisältää aloitukseen ja maksuihin liittyvää tärkeää tietoa. Perheiden velvollisuus on tutustua asiakirjojen sisältöön.</p> \
   <h2>Asiakasmaksuihin liittyvät ohjeet ja lomakkeet:</h2>\
   <p><a href="https://www.lempaala.fi/varhaiskasvatuksenasiakasmaksut/">https://www.lempaala.fi/varhaiskasvatuksenasiakasmaksut/</a></p> \
@@ -43,7 +44,9 @@ decision.instructions.PRESCHOOL_DAYCARE=\
   Mikäli kieltäydytte paikasta ja lapselle haetaan uutta täydentävän toiminnan paikkaa, on se tehtävä uudella hakemuksella. </p> \
   <p>Jos lapsi ei aloita vastaanottamassanne paikassa, eikä paikkaa ole peruttu ennen ilmoituksenne mukaista alkamisajankohtaa, teiltä peritään puolet kuukausimaksusta.</p> \
   <p>Esiopetusta täydentävä varhaiskasvatus<br/> \
-  Asiakasmaksu määräytyy huoltajien bruttotulojen perusteella varhaiskasvatuksen asiakasmaksulain mukaisesti. Huoltajien tulee tehdä tuloselvitys maksun määrittämiseksi tai heidän tulee antaa suostumus korkeimpaan asiakasmaksuun täydentävän varhaiskasvatuksen aloittamiskuukauden aikana. Mikäli tuloselvitystä ei toimiteta, peritään korkein asiakasmaksu (Laki varhaiskasvatuksen asiakasmaksuista 5 §).</p> \
+  Asiakasmaksu määräytyy huoltajien bruttotulojen perusteella varhaiskasvatuksen asiakasmaksulain mukaisesti. Uusien asiakkaiden tulee toimittaa perheen tulotiedot maksun määräämiseksi tai antaa suostumus korkeimpaan asiakasmaksuun kuukauden kuluessa varhaiskasvatuksen aloittamisesta. \
+  Mikäli tulotietoja ei toimiteta asiakasmaksuihin määräaikaan mennessä, voidaan periä korkein asiakasmaksu (Laki varhaiskasvatuksen asiakasmaksuista § 5).</p>\
+  <p>Selvitys perheen tuloista annetaan varhaiskasvatuksen verkkopalvelun kautta tuloselvityslomakkeella.</p>\
   <p>Esiopetuksen kerhot<br/> \
   Esiopetuksen kerhotoiminnassa on kiinteä kuukausimaksu, valitun palveluntarpeen mukaan. \
   Maksuista voi hakea maksuvapautusta varhaiskasvatuksen maksurajojen mukaisesti.</p> \
@@ -58,7 +61,9 @@ decision.instructions.PRESCHOOL_CLUB=\
   Mikäli kieltäydytte paikasta ja lapselle haetaan uutta täydentävän toiminnan paikkaa, on se tehtävä uudella hakemuksella. </p> \
   <p>Jos lapsi ei aloita vastaanottamassanne paikassa, eikä paikkaa ole peruttu ennen ilmoituksenne mukaista alkamisajankohtaa, teiltä peritään puolet kuukausimaksusta.</p> \
   <p>Esiopetusta täydentävä varhaiskasvatus<br/> \
-  Asiakasmaksu määräytyy huoltajien bruttotulojen perusteella varhaiskasvatuksen asiakasmaksulain mukaisesti. Huoltajien tulee tehdä tuloselvitys maksun määrittämiseksi tai heidän tulee antaa suostumus korkeimpaan asiakasmaksuun sen kalenterikuukauden loppuun mennessä, kun hoitosuhde alkaa. Mikäli tuloselvitystä ei toimiteta, peritään korkein asiakasmaksu (Laki varhaiskasvatuksen asiakasmaksuista 5 §).</p> \
+  Asiakasmaksu määräytyy huoltajien bruttotulojen perusteella varhaiskasvatuksen asiakasmaksulain mukaisesti. Uusien asiakkaiden tulee toimittaa perheen tulotiedot maksun määräämiseksi tai antaa suostumus korkeimpaan asiakasmaksuun kuukauden kuluessa varhaiskasvatuksen aloittamisesta. \
+  Mikäli tulotietoja ei toimiteta asiakasmaksuihin määräaikaan mennessä, voidaan periä korkein asiakasmaksu (Laki varhaiskasvatuksen asiakasmaksuista § 5).</p>\
+  <p>Selvitys perheen tuloista annetaan varhaiskasvatuksen verkkopalvelun kautta tuloselvityslomakkeella.</p>\
   <p>Esiopetuksen kerhot<br/> \
   Esiopetuksen kerhotoiminnassa on kiinteä kuukausimaksu, valitun palveluntarpeen mukaan. \
   Maksuista voi hakea maksuvapautusta varhaiskasvatuksen maksurajojen mukaisesti.</p> \

--- a/service/src/main/resources/WEB-INF/templates/lempaala/daycare/voucher/decision.properties
+++ b/service/src/main/resources/WEB-INF/templates/lempaala/daycare/voucher/decision.properties
@@ -16,7 +16,9 @@ decision.instructions=\
   <h2>Sovellettava lainsäädäntö</h2><p>Varhaiskasvatuslaki</p>\
   <p>Tämä päätös poistaa lapsen varhaiskasvatushakemuksen. Mikäli kieltäydytte lapsikohtaisesta varhaiskasvatuksen palvelusetelistä ja lapselle haetaan uutta varhaiskasvatuspaikkaa, on se tehtävä uudella hakemuksella.</p>
 decision.legalInstructions=\
-  <p>Palvelusetelin arvosta tehdään erillinen päätös. Uusien asiakkaiden tulee toimittaa tuloselvitys omavastuuosuuden määrittämiseksi tai antaa suostumus korkeimpaan asiakasmaksuun kuukauden kuluessa varhaiskasvatuksen aloittamisesta. Mikäli tuloselvitystä ei toimiteta, peritään korkein omavastuuosuus (Laki varhaiskasvatuksen asiakasmaksuista 5 §). Palvelusetelipaikasta irtisanoutumisaika on yksi kuukausi.</p>\
+  <p>Palvelusetelin arvosta tehdään erillinen päätös. Uusien asiakkaiden tulee toimittaa perheen tulotiedot maksun määräämiseksi tai antaa suostumus korkeimpaan asiakasmaksuun kuukauden kuluessa varhaiskasvatuksen aloittamisesta. Mikäli tulotietoja ei toimiteta asiakasmaksuihin määräaikaan mennessä, voidaan periä korkein asiakasmaksu (Laki varhaiskasvatuksen asiakasmaksuista § 5).</p>\
+  <p>Selvitys perheen tuloista annetaan varhaiskasvatuksen verkkopalvelun kautta tuloselvityslomakkeella.</p> \
+  <p>Palvelusetelipaikasta irtisanoutumisaika on yksi kuukausi.</p>\
   <p>Hoidon aloitukseen liittyvä Tervetuloa-paketti löytyy varhaiskasvatuksen nettisivuilta. Paketti sisältää aloitukseen ja maksuihin liittyvää tärkeää tietoa. Perheiden velvollisuus on tutustua asiakirjojen sisältöön.</p> \
   <h2>Asiakasmaksuihin liittyvät ohjeet ja lomakkeet:</h2>\
   <p><a href="https://www.lempaala.fi/varhaiskasvatuksenasiakasmaksut/">https://www.lempaala.fi/varhaiskasvatuksenasiakasmaksut/</a></p>\

--- a/service/src/main/resources/WEB-INF/templates/nokia/daycare/decision.properties
+++ b/service/src/main/resources/WEB-INF/templates/nokia/daycare/decision.properties
@@ -19,7 +19,9 @@ decision.instructions=\
   <p>Tämä päätös poistaa lapsen varhaiskasvatushakemuksen.\
   Mikäli kieltäydytte paikasta ja lapselle haetaan uutta varhaiskasvatuspaikkaa, on se tehtävä uudella hakemuksella, noudattaen varhaiskasvatuslain 17 §:n mukaisia hakuaikoja.</p>\
   <p>Jos lapsi ei aloita vastaanottamassanne varhaiskasvatuspaikassa, eikä paikkaa ole peruttu ennen ilmoituksenne mukaista alkamisajankohtaa, peritään puolet kuukausimaksusta. Lapsen tulee aloittaa varhaiskasvatuksessa kahden viikon kuluessa ilmoitetusta aloittamispäivästä, muutoin päätös varhaiskasvatukseen ottamisesta raukeaa.</p>\
-  <p>Varhaiskasvatuksen aloitusta voidaan siirtää enintään kaksi viikkoa eteenpäin hakemuksessa ilmoitetusta aloituspäivämäärästä alkaen. Varhaiskasvatuksen asiakasmaksu alkaa siitä päivästä lukien, minkä olette vahvistaneet alkamispäiväksi. Uusien asiakkaiden tulee toimittaa asiakasmaksulomake maksun määrittämiseksi tai antaa suostumus korkeimpaan asiakasmaksuun sen kalenterikuukauden kuluessa jona lapsi aloittaa varhaiskasvatuksessa. Mikäli asiakasmaksulomaketta ei toimiteta varhaiskasvatuksen asiakaslaskutukseen määräaikaan mennessä, peritään korkein asiakasmaksu (Laki varhaiskasvatuksen asiakasmaksuista 5 §).</p>\
+  <p>Varhaiskasvatuksen aloitusta voidaan siirtää enintään kaksi viikkoa eteenpäin hakemuksessa ilmoitetusta aloituspäivämäärästä alkaen. Varhaiskasvatuksen asiakasmaksu alkaa siitä päivästä lukien, minkä olette vahvistaneet alkamispäiväksi. Uusien asiakkaiden tulee toimittaa perheen tulotiedot maksun määräämiseksi tai antaa suostumus korkeimpaan asiakasmaksuun kuukauden kuluessa varhaiskasvatuksen aloittamisesta. \
+  Mikäli tulotietoja ei toimiteta asiakasmaksuihin määräaikaan mennessä, voidaan periä korkein asiakasmaksu (Laki varhaiskasvatuksen asiakasmaksuista § 5).</p>\
+  <p>Selvitys perheen tuloista annetaan varhaiskasvatuksen verkkopalvelun kautta tuloselvityslomakkeella.</p>\
   <h2>Asiakasmaksuihin liittyvät ohjeet ja lomakkeet:</h2>\
   <p><a href="https://www.nokiankaupunki.fi/varhaiskasvatus-ja-koulutus/varhaiskasvatuspalvelut/varhaiskasvatuksen-maksut-tuet-palveluseteli/varhaiskasvatuksen-asiakasmaksut-2/#f95b740d">Varhaiskasvatuksen asiakasmaksut - Nokian kaupunki</a></p>\
   <p>Kotihoidon tai yksityisen hoidon tuen saajan on ilmoitettava viipymättä Kelaan varhaiskasvatuksen alkamisesta.</p>
@@ -38,7 +40,9 @@ decision.instructions.PRESCHOOL_DAYCARE=\
   Mikäli kieltäydytte paikasta ja lapselle haetaan uutta täydentävän toiminnan paikkaa, on se tehtävä uudella hakemuksella. </p>\
   <p>Jos lapsi ei aloita vastaanottamassanne paikassa, eikä paikkaa ole peruttu ennen ilmoituksenne mukaista alkamisajankohtaa, teiltä peritään puolet kuukausimaksusta.</p>\
   <p>Esiopetusta täydentävä varhaiskasvatus<br/>\
-  Asiakasmaksu määräytyy huoltajien bruttotulojen perusteella varhaiskasvatuksen asiakasmaksulain mukaisesti. Huoltajien tulee tehdä tuloselvitys maksun määrittämiseksi tai heidän tulee antaa suostumus korkeimpaan asiakasmaksuun täydentävän varhaiskasvatuksen aloittamiskuukauden aikana. Mikäli tuloselvitystä ei toimiteta, peritään korkein asiakasmaksu (Laki varhaiskasvatuksen asiakasmaksuista 5 §).</p>\
+  Asiakasmaksu määräytyy huoltajien bruttotulojen perusteella varhaiskasvatuksen asiakasmaksulain mukaisesti. Uusien asiakkaiden tulee toimittaa perheen tulotiedot maksun määräämiseksi tai antaa suostumus korkeimpaan asiakasmaksuun kuukauden kuluessa varhaiskasvatuksen aloittamisesta. \
+  Mikäli tulotietoja ei toimiteta asiakasmaksuihin määräaikaan mennessä, voidaan periä korkein asiakasmaksu (Laki varhaiskasvatuksen asiakasmaksuista § 5).</p>\
+  <p>Selvitys perheen tuloista annetaan varhaiskasvatuksen verkkopalvelun kautta tuloselvityslomakkeella.</p>\
   <p>Esiopetuksen kerhot<br/>\
   Esiopetuksen kerhotoiminnassa on kiinteä kuukausimaksu, valitun palveluntarpeen mukaan.\
   Maksuista voi hakea maksuvapautusta varhaiskasvatuksen maksurajojen mukaisesti.</p>\
@@ -53,7 +57,8 @@ decision.instructions.PRESCHOOL_CLUB=\
   Mikäli kieltäydytte paikasta ja lapselle haetaan uutta täydentävän toiminnan paikkaa, on se tehtävä uudella hakemuksella. </p>\
   <p>Jos lapsi ei aloita vastaanottamassanne paikassa, eikä paikkaa ole peruttu ennen ilmoituksenne mukaista alkamisajankohtaa, teiltä peritään puolet kuukausimaksusta.</p>\
   <p>Esiopetusta täydentävä varhaiskasvatus<br/>\
-  Asiakasmaksu määräytyy huoltajien bruttotulojen perusteella varhaiskasvatuksen asiakasmaksulain mukaisesti. Huoltajien tulee tehdä tuloselvitys maksun määrittämiseksi tai heidän tulee antaa suostumus korkeimpaan asiakasmaksuun sen kalenterikuukauden loppuun mennessä, kun hoitosuhde alkaa. Mikäli tuloselvitystä ei toimiteta, peritään korkein asiakasmaksu (Laki varhaiskasvatuksen asiakasmaksuista 5 §).</p>\
+  Asiakasmaksu määräytyy huoltajien bruttotulojen perusteella varhaiskasvatuksen asiakasmaksulain mukaisesti. Uusien asiakkaiden tulee toimittaa perheen tulotiedot maksun määräämiseksi tai antaa suostumus korkeimpaan asiakasmaksuun kuukauden kuluessa varhaiskasvatuksen aloittamisesta. Mikäli tulotietoja ei toimiteta asiakasmaksuihin määräaikaan mennessä, voidaan periä korkein asiakasmaksu (Laki varhaiskasvatuksen asiakasmaksuista § 5).</p>\
+  <p>Selvitys perheen tuloista annetaan varhaiskasvatuksen verkkopalvelun kautta tuloselvityslomakkeella.</p>\
   <p>Esiopetuksen kerhot<br/>\
   Esiopetuksen kerhotoiminnassa on kiinteä kuukausimaksu, valitun palveluntarpeen mukaan.\
   Maksuista voi hakea maksuvapautusta varhaiskasvatuksen maksurajojen mukaisesti.</p>\

--- a/service/src/main/resources/WEB-INF/templates/nokia/daycare/voucher/decision.properties
+++ b/service/src/main/resources/WEB-INF/templates/nokia/daycare/voucher/decision.properties
@@ -16,7 +16,9 @@ decision.instructions=\
   <h2>Sovelletut oikeusohjeet</h2><p>Varhaiskasvatuslaki</p>\
   <p>Tämä päätös poistaa lapsen varhaiskasvatushakemuksen. Mikäli kieltäydytte lapsikohtaisesta varhaiskasvatuksen palvelusetelistä ja lapselle haetaan uutta varhaiskasvatuspaikkaa, on se tehtävä uudella hakemuksella.</p>
 decision.legalInstructions=\
-  <p>Palvelusetelin arvosta tehdään erillinen päätös. Uusien asiakkaiden tulee toimittaa tuloselvitys omavastuuosuuden määrittämiseksi tai antaa suostumus korkeimpaan asiakasmaksuun kuukauden kuluessa varhaiskasvatuksen aloittamisesta. Mikäli tuloselvitystä ei toimiteta, peritään korkein omavastuuosuus (Laki varhaiskasvatuksen asiakasmaksuista 5 §). Palvelusetelipaikasta irtisanoutumisaika on yksi kuukausi.</p>\
+  <p>Palvelusetelin arvosta tehdään erillinen päätös. Uusien asiakkaiden tulee toimittaa perheen tulotiedot maksun määräämiseksi tai antaa suostumus korkeimpaan asiakasmaksuun kuukauden kuluessa varhaiskasvatuksen aloittamisesta. Mikäli tulotietoja ei toimiteta asiakasmaksuihin määräaikaan mennessä, voidaan periä korkein asiakasmaksu (Laki varhaiskasvatuksen asiakasmaksuista § 5).</p>\
+  <p>Selvitys perheen tuloista annetaan varhaiskasvatuksen verkkopalvelun kautta tuloselvityslomakkeella.</p> \
+  <p>Palvelusetelipaikasta irtisanoutumisaika on yksi kuukausi.</p>\
   <p>Hoidon aloitukseen liittyvä Tervetuloa-paketti löytyy varhaiskasvatuksen nettisivuilta. Paketti sisältää aloitukseen ja maksuihin liittyvää tärkeää tietoa. Perheiden velvollisuus on tutustua asiakirjojen sisältöön.</p> \
   <h2>Asiakasmaksuihin liittyvät ohjeet ja lomakkeet:</h2>\
   <p><a href="https://www.nokiankaupunki.fi/varhaiskasvatus-ja-koulutus/varhaiskasvatuspalvelut/varhaiskasvatuksen-maksut-tuet-palveluseteli/varhaiskasvatuksen-asiakasmaksut-2/#f95b740d">Varhaiskasvatuksen asiakasmaksut - Nokian kaupunki</a></p>\

--- a/service/src/main/resources/WEB-INF/templates/orivesi/daycare/decision.properties
+++ b/service/src/main/resources/WEB-INF/templates/orivesi/daycare/decision.properties
@@ -19,7 +19,8 @@ decision.instructions=\
   <p>Tämä päätös poistaa lapsen varhaiskasvatushakemuksen.\
   Mikäli kieltäydytte paikasta ja lapselle haetaan uutta varhaiskasvatuspaikkaa, on se tehtävä uudella hakemuksella, noudattaen varhaiskasvatuslain 17 §:n mukaisia hakuaikoja.</p>\
   <p>Jos lapsi ei aloita vastaanottamassanne varhaiskasvatuspaikassa, eikä paikkaa ole peruttu ennen ilmoituksenne mukaista alkamisajankohtaa, peritään puolet kuukausimaksusta. Lapsen tulee aloittaa varhaiskasvatuksessa kahden viikon kuluessa ilmoitetusta aloittamispäivästä, muutoin päätös varhaiskasvatukseen ottamisesta raukeaa.</p>\
-  <p>Varhaiskasvatuksen aloitusta voidaan siirtää enintään kaksi viikkoa eteenpäin hakemuksessa ilmoitetusta aloituspäivämäärästä alkaen. Varhaiskasvatuksen asiakasmaksu alkaa siitä päivästä lukien, minkä olette vahvistaneet alkamispäiväksi. Uusien asiakkaiden tulee toimittaa asiakasmaksulomake maksun määrittämiseksi tai antaa suostumus korkeimpaan asiakasmaksuun sen kalenterikuukauden kuluessa jona lapsi aloittaa varhaiskasvatuksessa. Mikäli asiakasmaksulomaketta ei toimiteta varhaiskasvatuksen asiakaslaskutukseen määräaikaan mennessä, peritään korkein asiakasmaksu (Laki varhaiskasvatuksen asiakasmaksuista 5 §).</p>\
+  <p>Varhaiskasvatuksen aloitusta voidaan siirtää enintään kaksi viikkoa eteenpäin hakemuksessa ilmoitetusta aloituspäivämäärästä alkaen. Varhaiskasvatuksen asiakasmaksu alkaa siitä päivästä lukien, minkä olette vahvistaneet alkamispäiväksi. Uusien asiakkaiden tulee toimittaa perheen tulotiedot maksun määräämiseksi tai antaa suostumus korkeimpaan asiakasmaksuun kuukauden kuluessa varhaiskasvatuksen aloittamisesta. Mikäli tulotietoja ei toimiteta asiakasmaksuihin määräaikaan mennessä, voidaan periä korkein asiakasmaksu (Laki varhaiskasvatuksen asiakasmaksuista § 5).</p>\
+  <p>Selvitys perheen tuloista annetaan varhaiskasvatuksen verkkopalvelun kautta tuloselvityslomakkeella.</p>\
   <h2>Asiakasmaksuihin liittyvät ohjeet ja lomakkeet:</h2>\
   <p><a href="https://orivesi.fi/asukkaalle/kasvatus-ja-opetuspalvelut/varhaiskasvatus/varhaiskasvatuspaikan-hakeminen/">Varhaiskasvatuksen asiakasmaksut - Oriveden kaupunki</a></p>\
   <p>Kotihoidon tai yksityisen hoidon tuen saajan on ilmoitettava viipymättä Kelaan varhaiskasvatuksen alkamisesta.</p>
@@ -38,7 +39,8 @@ decision.instructions.PRESCHOOL_DAYCARE=\
   Mikäli kieltäydytte paikasta ja lapselle haetaan uutta täydentävän toiminnan paikkaa, on se tehtävä uudella hakemuksella. </p>\
   <p>Jos lapsi ei aloita vastaanottamassanne paikassa, eikä paikkaa ole peruttu ennen ilmoituksenne mukaista alkamisajankohtaa, teiltä peritään puolet kuukausimaksusta.</p>\
   <p>Esiopetusta täydentävä varhaiskasvatus<br/>\
-  Asiakasmaksu määräytyy huoltajien bruttotulojen perusteella varhaiskasvatuksen asiakasmaksulain mukaisesti. Huoltajien tulee tehdä tuloselvitys maksun määrittämiseksi tai heidän tulee antaa suostumus korkeimpaan asiakasmaksuun täydentävän varhaiskasvatuksen aloittamiskuukauden aikana. Mikäli tuloselvitystä ei toimiteta, peritään korkein asiakasmaksu (Laki varhaiskasvatuksen asiakasmaksuista 5 §).</p>\
+  Asiakasmaksu määräytyy huoltajien bruttotulojen perusteella varhaiskasvatuksen asiakasmaksulain mukaisesti. Uusien asiakkaiden tulee toimittaa perheen tulotiedot maksun määräämiseksi tai antaa suostumus korkeimpaan asiakasmaksuun kuukauden kuluessa varhaiskasvatuksen aloittamisesta. Mikäli tulotietoja ei toimiteta asiakasmaksuihin määräaikaan mennessä, voidaan periä korkein asiakasmaksu (Laki varhaiskasvatuksen asiakasmaksuista § 5).</p>\
+  <p>Selvitys perheen tuloista annetaan varhaiskasvatuksen verkkopalvelun kautta tuloselvityslomakkeella.</p>\
   <p>Esiopetuksen kerhot<br/>\
   Esiopetuksen kerhotoiminnassa on kiinteä kuukausimaksu, valitun palveluntarpeen mukaan.\
   Maksuista voi hakea maksuvapautusta varhaiskasvatuksen maksurajojen mukaisesti.</p>\
@@ -53,7 +55,9 @@ decision.instructions.PRESCHOOL_CLUB=\
   Mikäli kieltäydytte paikasta ja lapselle haetaan uutta täydentävän toiminnan paikkaa, on se tehtävä uudella hakemuksella. </p>\
   <p>Jos lapsi ei aloita vastaanottamassanne paikassa, eikä paikkaa ole peruttu ennen ilmoituksenne mukaista alkamisajankohtaa, teiltä peritään puolet kuukausimaksusta.</p>\
   <p>Esiopetusta täydentävä varhaiskasvatus<br/>\
-  Asiakasmaksu määräytyy huoltajien bruttotulojen perusteella varhaiskasvatuksen asiakasmaksulain mukaisesti. Huoltajien tulee tehdä tuloselvitys maksun määrittämiseksi tai heidän tulee antaa suostumus korkeimpaan asiakasmaksuun sen kalenterikuukauden loppuun mennessä, kun hoitosuhde alkaa. Mikäli tuloselvitystä ei toimiteta, peritään korkein asiakasmaksu (Laki varhaiskasvatuksen asiakasmaksuista 5 §).</p>\
+  Asiakasmaksu määräytyy huoltajien bruttotulojen perusteella varhaiskasvatuksen asiakasmaksulain mukaisesti. Uusien asiakkaiden tulee toimittaa perheen tulotiedot maksun määräämiseksi tai antaa suostumus korkeimpaan asiakasmaksuun kuukauden kuluessa varhaiskasvatuksen aloittamisesta. \
+  Mikäli tulotietoja ei toimiteta asiakasmaksuihin määräaikaan mennessä, voidaan periä korkein asiakasmaksu (Laki varhaiskasvatuksen asiakasmaksuista § 5).</p>\
+  <p>Selvitys perheen tuloista annetaan varhaiskasvatuksen verkkopalvelun kautta tuloselvityslomakkeella.</p>\
   <p>Esiopetuksen kerhot<br/>\
   Esiopetuksen kerhotoiminnassa on kiinteä kuukausimaksu, valitun palveluntarpeen mukaan.\
   Maksuista voi hakea maksuvapautusta varhaiskasvatuksen maksurajojen mukaisesti.</p>\

--- a/service/src/main/resources/WEB-INF/templates/orivesi/daycare/voucher/decision.properties
+++ b/service/src/main/resources/WEB-INF/templates/orivesi/daycare/voucher/decision.properties
@@ -16,7 +16,9 @@ decision.instructions=\
   <h2>Sovelletut oikeusohjeet</h2><p>Varhaiskasvatuslaki</p>\
   <p>Tämä päätös poistaa lapsen varhaiskasvatushakemuksen. Mikäli kieltäydytte lapsikohtaisesta varhaiskasvatuksen palvelusetelistä ja lapselle haetaan uutta varhaiskasvatuspaikkaa, on se tehtävä uudella hakemuksella.</p>
 decision.legalInstructions=\
-  <p>Palvelusetelin arvosta tehdään erillinen päätös. Uusien asiakkaiden tulee toimittaa tuloselvitys omavastuuosuuden määrittämiseksi tai antaa suostumus korkeimpaan asiakasmaksuun kuukauden kuluessa varhaiskasvatuksen aloittamisesta. Mikäli tuloselvitystä ei toimiteta, peritään korkein omavastuuosuus (Laki varhaiskasvatuksen asiakasmaksuista 5 §). Palvelusetelipaikasta irtisanoutumisaika on yksi kuukausi.</p>\
+  <p>Palvelusetelin arvosta tehdään erillinen päätös. Uusien asiakkaiden tulee toimittaa perheen tulotiedot maksun määräämiseksi tai antaa suostumus korkeimpaan asiakasmaksuun kuukauden kuluessa varhaiskasvatuksen aloittamisesta. Mikäli tulotietoja ei toimiteta asiakasmaksuihin määräaikaan mennessä, voidaan periä korkein asiakasmaksu (Laki varhaiskasvatuksen asiakasmaksuista § 5).</p>\
+  <p>Selvitys perheen tuloista annetaan varhaiskasvatuksen verkkopalvelun kautta tuloselvityslomakkeella.</p> \
+  <p>Palvelusetelipaikasta irtisanoutumisaika on yksi kuukausi.</p>\
   <p>Hoidon aloitukseen liittyvä Tervetuloa-paketti löytyy varhaiskasvatuksen nettisivuilta. Paketti sisältää aloitukseen ja maksuihin liittyvää tärkeää tietoa. Perheiden velvollisuus on tutustua asiakirjojen sisältöön.</p> \
   <h2>Asiakasmaksuihin liittyvät ohjeet ja lomakkeet:</h2>\
   <p><a href="https://orivesi.fi/asukkaalle/kasvatus-ja-opetuspalvelut/varhaiskasvatus/varhaiskasvatuspaikan-hakeminen/">Varhaiskasvatuksen asiakasmaksut - Oriveden kaupunki</a></p>\

--- a/service/src/main/resources/WEB-INF/templates/pirkkala/daycare/decision.properties
+++ b/service/src/main/resources/WEB-INF/templates/pirkkala/daycare/decision.properties
@@ -19,7 +19,8 @@ decision.instructions=\
   <p>Tämä päätös poistaa lapsen varhaiskasvatushakemuksen. Mikäli kieltäydytte paikasta ja lapselle haetaan uutta varhaiskasvatuspaikkaa, on se tehtävä uudella hakemuksella, noudattaen varhaiskasvatuslain 17 §:n mukaisia hakuaikoja.</p>\
   <p>Jos lapsi ei aloita vastaanottamassanne varhaiskasvatuspaikassa, eikä paikkaa ole peruttu ennen ilmoituksenne mukaista alkamisajankohtaa, teiltä peritään puolet kuukausimaksusta. Lapsen tulee aloittaa varhaiskasvatuksessa kahden viikon kuluessa ilmoitetusta aloittamispäivästä, muutoin päätös varhaiskasvatukseen ottamisesta raukeaa.</p>\
   <p>Varhaiskasvatuksen aloitusta voidaan siirtää enintään kaksi viikkoa eteenpäin hakemuksessa ilmoitetusta aloituspäivämäärästä alkaen. Varhaiskasvatuksen asiakasmaksu alkaa siitä päivästä lukien, minkä olette vahvistaneet alkamispäiväksi. \
-  Uusien asiakkaiden tulee toimittaa asiakasmaksulomake maksun määrittämiseksi tai antaa suostumus korkeimpaan asiakasmaksuun kuukauden kuluessa varhaiskasvatuksen aloittamisesta. Mikäli asiakasmaksulomaketta ei toimiteta Varhaiskasvatuksen asiakasmaksuihin, peritään korkein asiakasmaksu (Laki varhaiskasvatuksen asiakasmaksuista 5 §).</p>\
+  Uusien asiakkaiden tulee toimittaa perheen tulotiedot maksun määräämiseksi tai antaa suostumus korkeimpaan asiakasmaksuun kuukauden kuluessa varhaiskasvatuksen aloittamisesta. Mikäli tulotietoja ei toimiteta asiakasmaksuihin määräaikaan mennessä, voidaan periä korkein asiakasmaksu (Laki varhaiskasvatuksen asiakasmaksuista § 5).</p>\
+  <p>Selvitys perheen tuloista annetaan varhaiskasvatuksen verkkopalvelun kautta tuloselvityslomakkeella.</p>\
   <h2>Asiakasmaksuihin liittyvät ohjeet ja lomakkeet:</h2>\
   <p><a href="https://www.pirkkala.fi/varhaiskasvatuksen-asiakasmaksut/">Varhaiskasvatuksen asiakasmaksut - Pirkkala</a></p> \
   <p>Kotihoidon tai yksityisen hoidon tuen saajan on ilmoitettava viipymättä Kelaan varhaiskasvatuksen alkamisesta.</p>
@@ -38,7 +39,8 @@ decision.instructions.PRESCHOOL_DAYCARE=\
   Mikäli kieltäydytte paikasta ja lapselle haetaan uutta täydentävän toiminnan paikkaa, on se tehtävä uudella hakemuksella. </p> \
   <p>Jos lapsi ei aloita vastaanottamassanne paikassa, eikä paikkaa ole peruttu ennen ilmoituksenne mukaista alkamisajankohtaa, teiltä peritään puolet kuukausimaksusta.</p> \
   <p>Esiopetusta täydentävä varhaiskasvatus<br/> \
-  Asiakasmaksu määräytyy huoltajien bruttotulojen perusteella varhaiskasvatuksen asiakasmaksulain mukaisesti. Huoltajien tulee tehdä tuloselvitys maksun määrittämiseksi tai heidän tulee antaa suostumus korkeimpaan asiakasmaksuun täydentävän varhaiskasvatuksen aloittamiskuukauden aikana. Mikäli tuloselvitystä ei toimiteta, peritään korkein asiakasmaksu (Laki varhaiskasvatuksen asiakasmaksuista 5 §).</p> \
+  Asiakasmaksu määräytyy huoltajien bruttotulojen perusteella varhaiskasvatuksen asiakasmaksulain mukaisesti. Uusien asiakkaiden tulee toimittaa perheen tulotiedot maksun määräämiseksi tai antaa suostumus korkeimpaan asiakasmaksuun kuukauden kuluessa varhaiskasvatuksen aloittamisesta. Mikäli tulotietoja ei toimiteta asiakasmaksuihin määräaikaan mennessä, voidaan periä korkein asiakasmaksu (Laki varhaiskasvatuksen asiakasmaksuista § 5).</p> \
+  <p>Selvitys perheen tuloista annetaan varhaiskasvatuksen verkkopalvelun kautta tuloselvityslomakkeella.</p>\
   <p>Esiopetuksen kerhot<br/> \
   Esiopetuksen kerhotoiminnassa on kiinteä kuukausimaksu, valitun palveluntarpeen mukaan. \
   Maksuista voi hakea maksuvapautusta varhaiskasvatuksen maksurajojen mukaisesti.</p> \
@@ -53,7 +55,9 @@ decision.instructions.PRESCHOOL_CLUB=\
   Mikäli kieltäydytte paikasta ja lapselle haetaan uutta täydentävän toiminnan paikkaa, on se tehtävä uudella hakemuksella. </p> \
   <p>Jos lapsi ei aloita vastaanottamassanne paikassa, eikä paikkaa ole peruttu ennen ilmoituksenne mukaista alkamisajankohtaa, teiltä peritään puolet kuukausimaksusta.</p> \
   <p>Esiopetusta täydentävä varhaiskasvatus<br/> \
-  Asiakasmaksu määräytyy huoltajien bruttotulojen perusteella varhaiskasvatuksen asiakasmaksulain mukaisesti. Huoltajien tulee tehdä tuloselvitys maksun määrittämiseksi tai heidän tulee antaa suostumus korkeimpaan asiakasmaksuun sen kalenterikuukauden loppuun mennessä, kun hoitosuhde alkaa. Mikäli tuloselvitystä ei toimiteta, peritään korkein asiakasmaksu (Laki varhaiskasvatuksen asiakasmaksuista 5 §).</p> \
+  Asiakasmaksu määräytyy huoltajien bruttotulojen perusteella varhaiskasvatuksen asiakasmaksulain mukaisesti. Uusien asiakkaiden tulee toimittaa perheen tulotiedot maksun määräämiseksi tai antaa suostumus korkeimpaan asiakasmaksuun kuukauden kuluessa varhaiskasvatuksen aloittamisesta. \
+  Mikäli tulotietoja ei toimiteta asiakasmaksuihin määräaikaan mennessä, voidaan periä korkein asiakasmaksu (Laki varhaiskasvatuksen asiakasmaksuista § 5).</p>\
+  <p>Selvitys perheen tuloista annetaan varhaiskasvatuksen verkkopalvelun kautta tuloselvityslomakkeella.</p>\
   <p>Esiopetuksen kerhot<br/> \
   Esiopetuksen kerhotoiminnassa on kiinteä kuukausimaksu, valitun palveluntarpeen mukaan. \
   Maksuista voi hakea maksuvapautusta varhaiskasvatuksen maksurajojen mukaisesti.</p> \

--- a/service/src/main/resources/WEB-INF/templates/pirkkala/daycare/voucher/decision.properties
+++ b/service/src/main/resources/WEB-INF/templates/pirkkala/daycare/voucher/decision.properties
@@ -16,7 +16,9 @@ decision.instructions=\
   <h2>Sovelletut oikeusohjeet</h2><p>Varhaiskasvatuslaki</p>\
   <p>Tämä päätös poistaa lapsen varhaiskasvatushakemuksen. Mikäli kieltäydytte lapsikohtaisesta varhaiskasvatuksen palvelusetelistä ja lapselle haetaan uutta varhaiskasvatuspaikkaa, on se tehtävä uudella hakemuksella.</p>
 decision.legalInstructions=\
-  <p>Palvelusetelin arvosta tehdään erillinen päätös. Uusien asiakkaiden tulee toimittaa tuloselvitys omavastuuosuuden määrittämiseksi tai antaa suostumus korkeimpaan asiakasmaksuun kuukauden kuluessa varhaiskasvatuksen aloittamisesta. Mikäli tuloselvitystä ei toimiteta, peritään korkein omavastuuosuus (Laki varhaiskasvatuksen asiakasmaksuista 5 §). Palvelusetelipaikasta irtisanoutumisaika on yksi kuukausi.</p>\
+  <p>Palvelusetelin arvosta tehdään erillinen päätös. Uusien asiakkaiden tulee toimittaa perheen tulotiedot maksun määräämiseksi tai antaa suostumus korkeimpaan asiakasmaksuun kuukauden kuluessa varhaiskasvatuksen aloittamisesta. Mikäli tulotietoja ei toimiteta asiakasmaksuihin määräaikaan mennessä, voidaan periä korkein asiakasmaksu (Laki varhaiskasvatuksen asiakasmaksuista § 5).</p>\
+  <p>Selvitys perheen tuloista annetaan varhaiskasvatuksen verkkopalvelun kautta tuloselvityslomakkeella.</p> \
+  <p>Palvelusetelipaikasta irtisanoutumisaika on yksi kuukausi.</p>\
   <p>Hoidon aloitukseen liittyvä Tervetuloa-paketti löytyy varhaiskasvatuksen nettisivuilta. Paketti sisältää aloitukseen ja maksuihin liittyvää tärkeää tietoa. Perheiden velvollisuus on tutustua asiakirjojen sisältöön.</p> \
   <h2>Asiakasmaksuihin liittyvät ohjeet ja lomakkeet:</h2>\
   <p><a href="https://www.pirkkala.fi/varhaiskasvatuksen-asiakasmaksut/">Varhaiskasvatuksen asiakasmaksut - Pirkkala</a></p>\

--- a/service/src/main/resources/WEB-INF/templates/tampere/daycare/decision.properties
+++ b/service/src/main/resources/WEB-INF/templates/tampere/daycare/decision.properties
@@ -21,8 +21,9 @@ decision.instructions=\
   <p>Lapsen tulee aloittaa varhaiskasvatuksessa kahden viikon kuluessa ilmoitetusta aloittamispäivästä, muutoin päätös varhaiskasvatukseen ottamisesta raukeaa. \
   Varhaiskasvatuksen aloitusta voidaan siirtää enintään kaksi viikkoa eteenpäin hakemuksessa ilmoitetusta aloituspäivämäärästä alkaen.</p> \
   <p>Varhaiskasvatuksen asiakasmaksu alkaa siitä päivästä lukien, minkä olette vahvistaneet alkamispäiväksi. \
-  Uusien asiakkaiden tulee toimittaa asiakasmaksulomake maksun määrittämiseksi tai antaa suostumus korkeimpaan asiakasmaksuun kuukauden kuluessa varhaiskasvatuksen aloittamisesta. \
-  Mikäli asiakasmaksulomaketta ei toimiteta Varhaiskasvatuksen ja esiopetuksen asiakasmaksuihin määräaikaan mennessä, peritään korkein asiakasmaksu (Laki varhaiskasvatuksen asiakasmaksuista 5 §).</p>\
+  Uusien asiakkaiden tulee toimittaa perheen tulotiedot maksun määräämiseksi tai antaa suostumus korkeimpaan asiakasmaksuun kuukauden kuluessa varhaiskasvatuksen aloittamisesta. \
+  Mikäli tulotietoja ei toimiteta asiakasmaksuihin määräaikaan mennessä, voidaan periä korkein asiakasmaksu (Laki varhaiskasvatuksen asiakasmaksuista § 5).</p> \
+  <p>Selvitys perheen tuloista annetaan varhaiskasvatuksen verkkopalvelun kautta tuloselvityslomakkeella.</p>\
   <h2>Asiakasmaksuihin liittyvät ohjeet ja lomakkeet:</h2>\
   <p><a href="https://www.tampere.fi/varhaiskasvatusasiakasmaksut">https://www.tampere.fi/varhaiskasvatusasiakasmaksut</a></p> \
   <p>Kotihoidon tai yksityisen hoidon tuen saajan on ilmoitettava viipymättä Kelaan varhaiskasvatuksen alkamisesta.</p>
@@ -41,7 +42,8 @@ decision.instructions.PRESCHOOL_DAYCARE=\
   Mikäli kieltäydytte paikasta ja lapselle haetaan uutta täydentävän toiminnan paikkaa, on se tehtävä uudella hakemuksella. </p> \
   <p>Jos lapsi ei aloita vastaanottamassanne paikassa, eikä paikkaa ole peruttu ennen ilmoituksenne mukaista alkamisajankohtaa, teiltä peritään puolet kuukausimaksusta.</p> \
   <p>Esiopetusta täydentävä varhaiskasvatus<br/> \
-  Asiakasmaksu määräytyy huoltajien bruttotulojen perusteella varhaiskasvatuslain mukaisesti. Huoltajien tulee toimittaa perheen tulotiedot maksun määräämiseksi tai antaa suostumus korkeimpaan asiakasmaksuun kuukauden kuluessa varhaiskasvatuksen aloittamisesta. Mikäli tulotietoja ei toimiteta asiakasmaksuihin määräaikaan mennessä, voidaan periä korkein asiakasmaksu (Laki varhaiskasvatuksen asiakasmaksuista § 5).</p> \
+  Asiakasmaksu määräytyy huoltajien bruttotulojen perusteella varhaiskasvatuslain mukaisesti. Uusien asiakkaiden tulee toimittaa perheen tulotiedot maksun määräämiseksi tai antaa suostumus korkeimpaan asiakasmaksuun kuukauden kuluessa varhaiskasvatuksen aloittamisesta. Mikäli tulotietoja ei toimiteta asiakasmaksuihin määräaikaan mennessä, voidaan periä korkein asiakasmaksu (Laki varhaiskasvatuksen asiakasmaksuista § 5).</p> \
+  <p>Selvitys perheen tuloista annetaan varhaiskasvatuksen verkkopalvelun kautta tuloselvityslomakkeella.</p> \
   <p>Esiopetusta täydentävän toiminnan maksuihin liittyvät ohjeet ja lomakkeet:<br/> \
   <a href="https://www.tampere.fi/varhaiskasvatus-ja-esiopetus/varhaiskasvatuksen-ja-esiopetuksen-asiakasmaksut/esiopetusta-taydentavan-toiminnan-maksut">https://www.tampere.fi/varhaiskasvatus-ja-esiopetus/varhaiskasvatuksen-ja-esiopetuksen-asiakasmaksut/esiopetusta-taydentavan-toiminnan-maksut</a></p>
 decision.instructions.PRESCHOOL_CLUB=\
@@ -53,7 +55,8 @@ decision.instructions.PRESCHOOL_CLUB=\
   Mikäli kieltäydytte paikasta ja lapselle haetaan uutta täydentävän toiminnan paikkaa, on se tehtävä uudella hakemuksella. </p> \
   <p>Jos lapsi ei aloita vastaanottamassanne paikassa, eikä paikkaa ole peruttu ennen ilmoituksenne mukaista alkamisajankohtaa, teiltä peritään puolet kuukausimaksusta.</p> \
   <p>Esiopetusta täydentävä varhaiskasvatus<br/> \
-  Asiakasmaksu määräytyy huoltajien bruttotulojen perusteella varhaiskasvatuksen asiakasmaksulain mukaisesti. Huoltajien tulee toimittaa asiakasmaksulomake maksun määrittämiseksi tai heidän tulee antaa suostumus korkeimpaan asiakasmaksuun kuukauden kuluessa täydentävän varhaiskasvatuksen aloittamisesta. Mikäli asiakasmaksulomaketta ei toimiteta Varhaiskasvatuksen ja esiopetuksen asiakasmaksuihin määräaikaan mennessä, peritään korkein asiakasmaksu (Laki varhaiskasvatuksen asiakasmaksuista 5 §).</p> \
+  Asiakasmaksu määräytyy huoltajien bruttotulojen perusteella varhaiskasvatuksen asiakasmaksulain mukaisesti. Uusien asiakkaiden tulee toimittaa perheen tulotiedot maksun määräämiseksi tai antaa suostumus korkeimpaan asiakasmaksuun kuukauden kuluessa varhaiskasvatuksen aloittamisesta. Mikäli tulotietoja ei toimiteta asiakasmaksuihin määräaikaan mennessä, voidaan periä korkein asiakasmaksu (Laki varhaiskasvatuksen asiakasmaksuista § 5).</p> \
+  <p>Selvitys perheen tuloista annetaan varhaiskasvatuksen verkkopalvelun kautta tuloselvityslomakkeella.</p> \
   <p>Esiopetuksen kerhot<br/> \
   Esiopetuksen kerhotoiminnassa on kiinteä kuukausimaksu, valitun palveluntarpeen mukaan. \
   Maksuista voi hakea maksuvapautusta varhaiskasvatuksen maksurajojen mukaisesti.</p> \

--- a/service/src/main/resources/WEB-INF/templates/tampere/daycare/voucher/decision.properties
+++ b/service/src/main/resources/WEB-INF/templates/tampere/daycare/voucher/decision.properties
@@ -15,7 +15,9 @@ decision.instructions=\
   <h2>Sovelletut oikeusohjeet</h2><p>Varhaiskasvatuslaki</p>\
   <p>Tämä päätös poistaa lapsen varhaiskasvatushakemuksen. Mikäli kieltäydytte lapsikohtaisesta varhaiskasvatuksen palvelusetelistä ja lapselle haetaan uutta varhaiskasvatuspaikkaa, on se tehtävä uudella hakemuksella.</p>
 decision.legalInstructions=\
-  <p>Palvelusetelin arvosta tehdään erillinen päätös. Uusien asiakkaiden tulee toimittaa asiakasmaksulomake omavastuuosuuden määrittämiseksi tai antaa suostumus korkeimpaan asiakasmaksuun kuukauden kuluessa varhaiskasvatuksen aloittamisesta. Mikäli asiakasmaksulomaketta ei toimiteta Varhaiskasvatuksen ja esiopetuksen asiakasmaksuihin määräaikaan mennessä, peritään korkein omavastuuosuus (Laki varhaiskasvatuksen asiakasmaksuista 5 §). Palvelusetelipaikasta irtisanoutumisaika on yksi kuukausi.</p>\
+  <p>Palvelusetelin arvosta tehdään erillinen päätös. Uusien asiakkaiden tulee toimittaa perheen tulotiedot maksun määräämiseksi tai antaa suostumus korkeimpaan asiakasmaksuun kuukauden kuluessa varhaiskasvatuksen aloittamisesta. Mikäli tulotietoja ei toimiteta asiakasmaksuihin määräaikaan mennessä, voidaan periä korkein asiakasmaksu (Laki varhaiskasvatuksen asiakasmaksuista § 5).</p> \
+  <p>Selvitys perheen tuloista annetaan varhaiskasvatuksen verkkopalvelun kautta tuloselvityslomakkeella.</p> \
+  <p>Palvelusetelipaikasta irtisanoutumisaika on yksi kuukausi.</p>\
   <h2>Asiakasmaksuihin liittyvät ohjeet ja lomakkeet:</h2>\
   <p><a href="https://www.tampere.fi/varhaiskasvatusasiakasmaksut">https://www.tampere.fi/varhaiskasvatusasiakasmaksut</a></p>\
   <p>Kotihoidon tai yksityisen hoidon tuen saajan on ilmoitettava viipymättä Kelaan varhaiskasvatuksen alkamisesta.</p>

--- a/service/src/main/resources/WEB-INF/templates/vesilahti/daycare/decision.properties
+++ b/service/src/main/resources/WEB-INF/templates/vesilahti/daycare/decision.properties
@@ -22,8 +22,8 @@ decision.instructions=\
   <p>Lapsen tulee aloittaa varhaiskasvatuksessa kahden viikon kuluessa ilmoitetusta aloittamispäivästä, muutoin päätös varhaiskasvatukseen ottamisesta raukeaa. \
   Varhaiskasvatuksen aloitusta voidaan siirtää enintään kaksi viikkoa eteenpäin hakemuksessa ilmoitetusta aloituspäivämäärästä alkaen.</p> \
   <p>Varhaiskasvatuksen asiakasmaksu alkaa siitä päivästä lukien, minkä olette vahvistaneet alkamispäiväksi. \
-  Uusien asiakkaiden tulee toimittaa asiakasmaksulomake maksun määrittämiseksi tai antaa suostumus korkeimpaan asiakasmaksuun kuukauden kuluessa varhaiskasvatuksen aloittamisesta. \
-  Mikäli asiakasmaksulomaketta ei toimiteta Varhaiskasvatuksen ja esiopetuksen asiakasmaksuihin määräaikaan mennessä, peritään korkein asiakasmaksu (Laki varhaiskasvatuksen asiakasmaksuista 5 §).</p>\
+  Uusien asiakkaiden tulee toimittaa perheen tulotiedot maksun määräämiseksi tai antaa suostumus korkeimpaan asiakasmaksuun kuukauden kuluessa varhaiskasvatuksen aloittamisesta. Mikäli tulotietoja ei toimiteta asiakasmaksuihin määräaikaan mennessä, voidaan periä korkein asiakasmaksu (Laki varhaiskasvatuksen asiakasmaksuista § 5).</p>\
+  <p>Selvitys perheen tuloista annetaan varhaiskasvatuksen verkkopalvelun kautta tuloselvityslomakkeella.</p> \
   <h2>Asiakasmaksuihin liittyvät ohjeet ja lomakkeet:</h2>\
   <p><a href="https://www.vesilahti.fi/varhaiskasvatus/asiakasmaksut">https://www.vesilahti.fi/varhaiskasvatus/asiakasmaksut</a></p> \
   <p>Kotihoidon tai yksityisen hoidon tuen saajan on ilmoitettava viipymättä Kelaan varhaiskasvatuksen alkamisesta.</p>
@@ -42,7 +42,8 @@ decision.instructions.PRESCHOOL_DAYCARE=\
   Mikäli kieltäydytte paikasta ja lapselle haetaan uutta täydentävän toiminnan paikkaa, on se tehtävä uudella hakemuksella. </p> \
   <p>Jos lapsi ei aloita vastaanottamassanne paikassa, eikä paikkaa ole peruttu ennen ilmoituksenne mukaista alkamisajankohtaa, teiltä peritään puolet kuukausimaksusta.</p> \
   <p>Esiopetusta täydentävä varhaiskasvatus<br/> \
-  Asiakasmaksu määräytyy huoltajien bruttotulojen perusteella varhaiskasvatuksen asiakasmaksulain mukaisesti. Huoltajien tulee toimittaa asiakasmaksulomake maksun määrittämiseksi tai heidän tulee antaa suostumus korkeimpaan asiakasmaksuun kuukauden kuluessa täydentävän varhaiskasvatuksen aloittamisesta. Mikäli asiakasmaksulomaketta ei toimiteta Varhaiskasvatuksen ja esiopetuksen asiakasmaksuihin määräaikaan mennessä, peritään korkein asiakasmaksu (Laki varhaiskasvatuksen asiakasmaksuista 5 §).</p> \
+  Asiakasmaksu määräytyy huoltajien bruttotulojen perusteella varhaiskasvatuksen asiakasmaksulain mukaisesti. Uusien asiakkaiden tulee toimittaa perheen tulotiedot maksun määräämiseksi tai antaa suostumus korkeimpaan asiakasmaksuun kuukauden kuluessa varhaiskasvatuksen aloittamisesta. Mikäli tulotietoja ei toimiteta asiakasmaksuihin määräaikaan mennessä, voidaan periä korkein asiakasmaksu (Laki varhaiskasvatuksen asiakasmaksuista § 5).</p> \
+  <p>Selvitys perheen tuloista annetaan varhaiskasvatuksen verkkopalvelun kautta tuloselvityslomakkeella.</p>\
   <p>Esiopetuksen kerhot<br/> \
   Esiopetuksen kerhotoiminnassa on kiinteä kuukausimaksu, valitun palveluntarpeen mukaan. \
   Maksuista voi hakea maksuvapautusta varhaiskasvatuksen maksurajojen mukaisesti.</p> \
@@ -57,7 +58,9 @@ decision.instructions.PRESCHOOL_CLUB=\
   Mikäli kieltäydytte paikasta ja lapselle haetaan uutta täydentävän toiminnan paikkaa, on se tehtävä uudella hakemuksella. </p> \
   <p>Jos lapsi ei aloita vastaanottamassanne paikassa, eikä paikkaa ole peruttu ennen ilmoituksenne mukaista alkamisajankohtaa, teiltä peritään puolet kuukausimaksusta.</p> \
   <p>Esiopetusta täydentävä varhaiskasvatus<br/> \
-  Asiakasmaksu määräytyy huoltajien bruttotulojen perusteella varhaiskasvatuksen asiakasmaksulain mukaisesti. Huoltajien tulee toimittaa asiakasmaksulomake maksun määrittämiseksi tai heidän tulee antaa suostumus korkeimpaan asiakasmaksuun kuukauden kuluessa täydentävän varhaiskasvatuksen aloittamisesta. Mikäli asiakasmaksulomaketta ei toimiteta Varhaiskasvatuksen ja esiopetuksen asiakasmaksuihin määräaikaan mennessä, peritään korkein asiakasmaksu (Laki varhaiskasvatuksen asiakasmaksuista 5 §).</p> \
+  Asiakasmaksu määräytyy huoltajien bruttotulojen perusteella varhaiskasvatuksen asiakasmaksulain mukaisesti. Uusien asiakkaiden tulee toimittaa perheen tulotiedot maksun määräämiseksi tai antaa suostumus korkeimpaan asiakasmaksuun kuukauden kuluessa varhaiskasvatuksen aloittamisesta. \
+  Mikäli tulotietoja ei toimiteta asiakasmaksuihin määräaikaan mennessä, voidaan periä korkein asiakasmaksu (Laki varhaiskasvatuksen asiakasmaksuista § 5).</p>\
+  <p>Selvitys perheen tuloista annetaan varhaiskasvatuksen verkkopalvelun kautta tuloselvityslomakkeella.</p>\
   <p>Esiopetuksen kerhot<br/> \
   Esiopetuksen kerhotoiminnassa on kiinteä kuukausimaksu, valitun palveluntarpeen mukaan. \
   Maksuista voi hakea maksuvapautusta varhaiskasvatuksen maksurajojen mukaisesti.</p> \

--- a/service/src/main/resources/WEB-INF/templates/ylojarvi/daycare/decision.properties
+++ b/service/src/main/resources/WEB-INF/templates/ylojarvi/daycare/decision.properties
@@ -20,8 +20,8 @@ decision.instructions=\
   Mikäli kieltäydytte paikasta ja lapselle haetaan uutta varhaiskasvatuspaikkaa, on se tehtävä uudella hakemuksella, noudattaen varhaiskasvatuslain 17 §:n mukaisia hakuaikoja.</p>\
   <p>Varhaiskasvatuksen aloitusta voidaan siirtää enintään kaksi viikkoa eteenpäin hakemuksessa ilmoitetusta aloituspäivämäärästä alkaen. \
   Varhaiskasvatuksen asiakasmaksu alkaa siitä päivästä lukien, minkä olette vahvistaneet alkamispäiväksi. \
-  Uusien asiakkaiden tulee  tulotiedot varhaiskasvatuksen asiakasmaksuihin <a href="mailto:varhaiskasvatuksenasiakasmaksut@ylojarvi.fi">varhaiskasvatuksenasiakasmaksut@ylojarvi.fi</a> tai antaa suostumus korkeimpaan asiakasmaksuun varhaiskasvatuksen aloittamiskuukauden aikana. \
-  Mikäli tuloselvitystä ei toimiteta varhaiskasvatuksen ja esiopetuksen asiakasmaksuihin määräaikaan mennessä, peritään korkein asiakasmaksu (Laki varhaiskasvatuksen asiakasmaksuista 5 §).</p>\
+  Uusien asiakkaiden tulee toimittaa perheen tulotiedot maksun määräämiseksi tai antaa suostumus korkeimpaan asiakasmaksuun kuukauden kuluessa varhaiskasvatuksen aloittamisesta. Mikäli tulotietoja ei toimiteta asiakasmaksuihin määräaikaan mennessä, voidaan periä korkein asiakasmaksu (Laki varhaiskasvatuksen asiakasmaksuista § 5).</p>\
+  <p>Selvitys perheen tuloista annetaan varhaiskasvatuksen verkkopalvelun kautta tuloselvityslomakkeella.</p>\
   <p>Hoidon aloitukseen liittyvä Tervetuloa-paketti löytyy varhaiskasvatuksen nettisivuilta. Paketti sisältää aloitukseen ja maksuihin liittyvää tärkeää tietoa. Perheiden velvollisuus on tutustua asiakirjojen sisältöön.</p> \
   <h2>Asiakasmaksuihin liittyvät ohjeet ja lomakkeet:</h2>\
   <p><a href="https://www.ylojarvi.fi/asiakasmaksut-varhaiskasvatuksessa/">https://www.ylojarvi.fi/asiakasmaksut-varhaiskasvatuksessa/</a></p> \
@@ -41,12 +41,14 @@ decision.instructions.PRESCHOOL_DAYCARE=\
   Mikäli kieltäydytte paikasta ja lapselle haetaan uutta täydentävän toiminnan paikkaa, on se tehtävä uudella hakemuksella. </p> \
   <p>Jos lapsi ei aloita vastaanottamassanne paikassa, eikä paikkaa ole peruttu ennen ilmoituksenne mukaista alkamisajankohtaa, teiltä peritään puolet kuukausimaksusta.</p> \
   <p>Esiopetusta täydentävä varhaiskasvatus<br/> \
-  Asiakasmaksu määräytyy huoltajien bruttotulojen perusteella varhaiskasvatuksen asiakasmaksulain mukaisesti. Huoltajien tulee tehdä tuloselvitys maksun määrittämiseksi tai heidän tulee antaa suostumus korkeimpaan asiakasmaksuun täydentävän varhaiskasvatuksen aloittamiskuukauden aikana. Mikäli tuloselvitystä ei toimiteta, peritään korkein asiakasmaksu (Laki varhaiskasvatuksen asiakasmaksuista 5 §).</p> \
+  Asiakasmaksu määräytyy huoltajien bruttotulojen perusteella varhaiskasvatuksen asiakasmaksulain mukaisesti. Uusien asiakkaiden tulee toimittaa perheen tulotiedot maksun määräämiseksi tai antaa suostumus korkeimpaan asiakasmaksuun kuukauden kuluessa varhaiskasvatuksen aloittamisesta. \
+  Mikäli tulotietoja ei toimiteta asiakasmaksuihin määräaikaan mennessä, voidaan periä korkein asiakasmaksu (Laki varhaiskasvatuksen asiakasmaksuista § 5).</p> \
+  <p>Selvitys perheen tuloista annetaan varhaiskasvatuksen verkkopalvelun kautta tuloselvityslomakkeella.</p>\
   <p>Esiopetuksen kerhot<br/> \
   Esiopetuksen kerhotoiminnassa on kiinteä kuukausimaksu, valitun palveluntarpeen mukaan. \
   Maksuista voi hakea maksuvapautusta varhaiskasvatuksen maksurajojen mukaisesti.</p> \
   <p>Esiopetusta täydentävän toiminnan maksuihin liittyvät ohjeet ja lomakkeet:<br/> \
-  <a href="https://www.ylojarvi.fi/asiakasmaksut-varhaiskasvatuksessa/">https://www.ylojarvi.fi/asiakasmaksut-varhaiskasvatuksessa/</a></p>\
+  <a href="https://www.ylojarvi.fi/asiakasmaksut-varhaiskasvatuksessa/">https://www.ylojarvi.fi/asiakasmaksut-varhaiskasvatuksessa/</a></p>
 decision.instructions.PRESCHOOL_CLUB=\
   <p>Päätöksessä ilmoitettu esiopetusta täydentävän toiminnan paikka tulee vastaanottaa tai hylätä viipymättä, viimeistään kahden viikon kuluessa tämän päätöksen tiedoksisaannista. \
   Paikan voi hyväksyä / hylätä sähköisesti osoitteessa <a href="https://evaka.ylojarvi.fi">https://evaka.ylojarvi.fi</a> (edellyttää tunnistautumista) tai ottamalla yhteyttä yksikön johtajaan</p> \
@@ -56,7 +58,9 @@ decision.instructions.PRESCHOOL_CLUB=\
   Mikäli kieltäydytte paikasta ja lapselle haetaan uutta täydentävän toiminnan paikkaa, on se tehtävä uudella hakemuksella. </p> \
   <p>Jos lapsi ei aloita vastaanottamassanne paikassa, eikä paikkaa ole peruttu ennen ilmoituksenne mukaista alkamisajankohtaa, teiltä peritään puolet kuukausimaksusta.</p> \
   <p>Esiopetusta täydentävä varhaiskasvatus<br/> \
-  Asiakasmaksu määräytyy huoltajien bruttotulojen perusteella varhaiskasvatuksen asiakasmaksulain mukaisesti. Huoltajien tulee tehdä tuloselvitys maksun määrittämiseksi tai heidän tulee antaa suostumus korkeimpaan asiakasmaksuun sen kalenterikuukauden loppuun mennessä, kun hoitosuhde alkaa. Mikäli tuloselvitystä ei toimiteta, peritään korkein asiakasmaksu (Laki varhaiskasvatuksen asiakasmaksuista 5 §).</p> \
+  Asiakasmaksu määräytyy huoltajien bruttotulojen perusteella varhaiskasvatuksen asiakasmaksulain mukaisesti. Uusien asiakkaiden tulee toimittaa perheen tulotiedot maksun määräämiseksi tai antaa suostumus korkeimpaan asiakasmaksuun kuukauden kuluessa varhaiskasvatuksen aloittamisesta. \
+  Mikäli tulotietoja ei toimiteta asiakasmaksuihin määräaikaan mennessä, voidaan periä korkein asiakasmaksu (Laki varhaiskasvatuksen asiakasmaksuista § 5).</p>\
+  <p>Selvitys perheen tuloista annetaan varhaiskasvatuksen verkkopalvelun kautta tuloselvityslomakkeella.</p>\
   <p>Esiopetuksen kerhot<br/> \
   Esiopetuksen kerhotoiminnassa on kiinteä kuukausimaksu, valitun palveluntarpeen mukaan. \
   Maksuista voi hakea maksuvapautusta varhaiskasvatuksen maksurajojen mukaisesti.</p> \

--- a/service/src/main/resources/WEB-INF/templates/ylojarvi/daycare/voucher/decision.properties
+++ b/service/src/main/resources/WEB-INF/templates/ylojarvi/daycare/voucher/decision.properties
@@ -16,7 +16,9 @@ decision.instructions=\
   <h2>Sovelletut oikeusohjeet</h2><p>Varhaiskasvatuslaki</p>\
   <p>Tämä päätös poistaa lapsen varhaiskasvatushakemuksen. Mikäli kieltäydytte lapsikohtaisesta varhaiskasvatuksen palvelusetelistä ja lapselle haetaan uutta varhaiskasvatuspaikkaa, on se tehtävä uudella hakemuksella.</p>
 decision.legalInstructions=\
-  <p>Palvelusetelin arvosta tehdään erillinen päätös. Uusien asiakkaiden tulee toimittaa tuloselvitys omavastuuosuuden määrittämiseksi tai antaa suostumus korkeimpaan asiakasmaksuun kuukauden kuluessa varhaiskasvatuksen aloittamisesta. Mikäli tuloselvitystä ei toimiteta, peritään korkein omavastuuosuus (Laki varhaiskasvatuksen asiakasmaksuista 5 §). Palvelusetelipaikasta irtisanoutumisaika on yksi kuukausi.</p>\
+  <p>Palvelusetelin arvosta tehdään erillinen päätös. Uusien asiakkaiden tulee toimittaa perheen tulotiedot maksun määräämiseksi tai antaa suostumus korkeimpaan asiakasmaksuun kuukauden kuluessa varhaiskasvatuksen aloittamisesta. Mikäli tulotietoja ei toimiteta asiakasmaksuihin määräaikaan mennessä, voidaan periä korkein asiakasmaksu (Laki varhaiskasvatuksen asiakasmaksuista § 5).</p>\
+  <p>Selvitys perheen tuloista annetaan varhaiskasvatuksen verkkopalvelun kautta tuloselvityslomakkeella.</p> \
+  <p>Palvelusetelipaikasta irtisanoutumisaika on yksi kuukausi.</p>\
   <p>Hoidon aloitukseen liittyvä Tervetuloa-paketti löytyy varhaiskasvatuksen nettisivuilta. Paketti sisältää aloitukseen ja maksuihin liittyvää tärkeää tietoa. Perheiden velvollisuus on tutustua asiakirjojen sisältöön.</p> \
   <h2>Asiakasmaksuihin liittyvät ohjeet ja lomakkeet:</h2>\
   <p><a href="https://www.ylojarvi.fi/asiakasmaksut-varhaiskasvatuksessa/">https://www.ylojarvi.fi/asiakasmaksut-varhaiskasvatuksessa/</a></p>\


### PR DESCRIPTION
Use same instruction text and logic for:
- municipal daycare decision
- voucher daycare decision
- preschool daycare decision
- preschool club decision