### PR TITLE
Fix next invoice number

### DIFF
--- a/service/src/main/kotlin/fi/lempaala/evaka/invoice/config/InvoiceConfiguration.kt
+++ b/service/src/main/kotlin/fi/lempaala/evaka/invoice/config/InvoiceConfiguration.kt
@@ -173,6 +173,6 @@ enum class Product(val nameFi: String, val code: String) {
 
 class LempaalaInvoiceNumberProvider : InvoiceNumberProvider {
     override fun getNextInvoiceNumber(tx: Database.Read): Long = tx
-        .createQuery { sql("SELECT max(number) FROM invoice WHERE number < 5400042258") }
+        .createQuery { sql("SELECT max(number) FROM invoice WHERE number >= 54000001 AND number < 5400042258") }
         .exactlyOneOrNull<Long>()?.let { it + 1 } ?: 54000001
 }

--- a/service/src/test/kotlin/fi/lempaala/evaka/invoice/LempaalaInvoiceNumberTest.kt
+++ b/service/src/test/kotlin/fi/lempaala/evaka/invoice/LempaalaInvoiceNumberTest.kt
@@ -99,7 +99,7 @@ class LempaalaInvoiceNumberTest : AbstractLempaalaIntegrationTest() {
     }
 
     @Test
-    fun `first invoice with new series start has correct number`() {
+    fun `first invoice with third series start has correct number`() {
         val invoices = db.transaction { tx ->
             val employee = DevEmployee(roles = setOf(UserRole.FINANCE_ADMIN)).also { tx.insert(it) }
             val clock = MockEvakaClock(HelsinkiDateTime.of(LocalDate.of(2025, 1, 7), LocalTime.of(12, 34)))
@@ -107,7 +107,19 @@ class LempaalaInvoiceNumberTest : AbstractLempaalaIntegrationTest() {
             tx.insert(
                 DevInvoice(
                     status = InvoiceStatus.SENT,
-                    number = 5400042258, // old series start
+                    number = 1, // first series start
+                    invoiceDate = LocalDate.of(2024, 11, 11),
+                    dueDate = LocalDate.of(2024, 11, 25),
+                    periodStart = LocalDate.of(2024, 10, 1),
+                    periodEnd = LocalDate.of(2024, 10, 31),
+                    headOfFamilyId = headOfFamilyId,
+                    areaId = AreaId(UUID.fromString("e23ed34d-1b35-48f0-b9a5-252d633be5b9")),
+                ),
+            )
+            tx.insert(
+                DevInvoice(
+                    status = InvoiceStatus.SENT,
+                    number = 5400042258, // second series start
                     invoiceDate = LocalDate.of(2024, 12, 9),
                     dueDate = LocalDate.of(2024, 12, 23),
                     periodStart = LocalDate.of(2024, 11, 1),


### PR DESCRIPTION
The first series start was 1: https://github.com/Tampere/trevaka/commit/82e92501ca375a3acaf97625928d55d094588af0#diff-b8e670be8f943ec8562d70a3506ec9f0917827b715ede8dd23ef7f3cf1a08475R36
Then it was changed to 5400042258 just before production: https://github.com/Tampere/trevaka/commit/bcb8f1acfd11a5f74044f10c5fc5d994bd6a221d

Next number should be 54000001, but at least test environment includes some invoice numbers starting from 1.