### PR TITLE
Add an implementation of getFreeChildren for Tampere config

### DIFF
--- a/service/src/test/kotlin/fi/tampere/trevaka/invoice/config/InvoiceConfigurationIT.kt
+++ b/service/src/test/kotlin/fi/tampere/trevaka/invoice/config/InvoiceConfigurationIT.kt
@@ -46,7 +46,6 @@ import fi.espoo.evaka.shared.security.PilotFeature
 import fi.tampere.trevaka.AbstractTampereIntegrationTest
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import java.math.BigDecimal
@@ -143,7 +142,6 @@ internal class InvoiceConfigurationIT : AbstractTampereIntegrationTest() {
     }
 
     @Test
-    @Disabled
     fun test8WeeksReserved() {
         db.transaction { tx ->
             tx.createUpdate {
@@ -164,7 +162,6 @@ internal class InvoiceConfigurationIT : AbstractTampereIntegrationTest() {
     }
 
     @Test
-    @Disabled
     fun test7WeeksReserved() {
         db.transaction { tx ->
             tx.createUpdate {


### PR DESCRIPTION
Interface member implemented using the boolean-returning query from the old implementation to filter the child list parameter of the new interface. Also fixed missing holiday-table dependency.