### PR TITLE
Enable suomi.fi-messages rest (prod)

### DIFF
--- a/infra/deploy/evaka-service.tf
+++ b/infra/deploy/evaka-service.tf
@@ -81,7 +81,7 @@ module "app_service" {
 
     # SfiEnv
     EVAKA_INTEGRATION_SFI_KEY_STORE_PASSWORD = var.evaka_integration_sfi_enabled ? "${local.param_prefix}/message-service/keystore/password" : null
-    EVAKA_INTEGRATION_SFI_REST_USERNAME      = var.evaka_integration_sfi_enabled && var.evaka_integeration_sfi_rest_enabled ? "${local.param_prefix}/service/sfi/username" : null
+    EVAKA_INTEGRATION_SFI_REST_USERNAME      = var.evaka_integration_sfi_enabled ? "${local.param_prefix}/service/sfi/username" : null
 
     # SfiPrintingEnv
     EVAKA_INTEGRATION_SFI_PRINTING_BILLING_ID       = var.evaka_integration_sfi_enabled ? "${local.param_prefix}/service/sfi/printing/id" : null
@@ -228,9 +228,9 @@ module "app_service" {
     EVAKA_INTEGRATION_SFI_SERVICE_IDENTIFIER      = var.evaka_integration_sfi_enabled ? var.sfi_msg_service_identifier : null
     EVAKA_INTEGRATION_SFI_CERTIFICATE_COMMON_NAME = var.evaka_integration_sfi_enabled ? var.sfi_msg_certificate_cn : null
     EVAKA_INTEGRATION_SFI_PRINTING_ENABLED        = var.evaka_integration_sfi_enabled ? var.sfi_msg_enable_printing : null
-    EVAKA_INTEGRATION_SFI_REST_ENABLED            = var.evaka_integration_sfi_enabled && var.evaka_integeration_sfi_rest_enabled ? true : null
-    EVAKA_INTEGRATION_SFI_REST_ADDRESS            = var.evaka_integration_sfi_enabled && var.evaka_integeration_sfi_rest_enabled ? var.environment == "prod" ? "https://api.messages.suomi.fi" : "https://api.messages-qa.suomi.fi" : null
-    EVAKA_INTEGRATION_SFI_REST_PASSWORD_SSM_NAME  = var.evaka_integration_sfi_enabled && var.evaka_integeration_sfi_rest_enabled ? "${local.param_prefix}/service/sfi/password" : null
+    EVAKA_INTEGRATION_SFI_REST_ENABLED            = var.evaka_integration_sfi_enabled ? true : null
+    EVAKA_INTEGRATION_SFI_REST_ADDRESS            = var.evaka_integration_sfi_enabled ? var.environment == "prod" ? "https://api.messages.suomi.fi" : "https://api.messages-qa.suomi.fi" : null
+    EVAKA_INTEGRATION_SFI_REST_PASSWORD_SSM_NAME  = var.evaka_integration_sfi_enabled ? "${local.param_prefix}/service/sfi/password" : null
 
     # SfiPrintingEnv
     EVAKA_INTEGRATION_SFI_PRINTING_FORCE_PRINT_FOR_ELECTRONIC_USER = var.evaka_integration_sfi_enabled ? var.sfi_msg_force_print_for_electronic_user : null
@@ -398,11 +398,6 @@ variable "evaka_integration_koski_enabled" {
 
 variable "evaka_integration_sfi_enabled" {
   type = bool
-}
-
-variable "evaka_integeration_sfi_rest_enabled" {
-  type    = bool
-  default = false
 }
 
 variable "tampere_summertime_absence_free_month" {

--- a/infra/deploy/variables/hameenkyro-test-apps.tfvars
+++ b/infra/deploy/variables/hameenkyro-test-apps.tfvars
@@ -44,7 +44,6 @@ dvv_modifications_service_xroadclientid       = "FI-TEST/MUN/0132947-3/hameenkyr
 dvv_mutp_update_enabled                       = false
 send_pending_decision_reminder_emails_enabled = true
 evaka_integration_sfi_enabled                 = true
-evaka_integeration_sfi_rest_enabled           = true
 
 evaka_job_inactive_employees_role_reset_enabled      = false
 evaka_job_send_missing_reservation_reminders_enabled = true

--- a/infra/deploy/variables/kangasala-test-apps.tfvars
+++ b/infra/deploy/variables/kangasala-test-apps.tfvars
@@ -37,7 +37,6 @@ dvv_modifications_service_xroadclientid       = "FI-TEST/MUN/1923299-5/kangasala
 dvv_mutp_update_enabled                       = false
 send_pending_decision_reminder_emails_enabled = true
 evaka_integration_sfi_enabled                 = true
-evaka_integeration_sfi_rest_enabled           = true
 
 evaka_job_inactive_employees_role_reset_enabled      = false
 evaka_job_send_missing_reservation_reminders_enabled = true

--- a/infra/deploy/variables/lempaala-test-apps.tfvars
+++ b/infra/deploy/variables/lempaala-test-apps.tfvars
@@ -37,7 +37,6 @@ dvv_modifications_service_xroadclientid       = "FI-TEST/MUN/0150783-1/lempaalae
 dvv_mutp_update_enabled                       = false
 send_pending_decision_reminder_emails_enabled = true
 evaka_integration_sfi_enabled                 = true
-evaka_integeration_sfi_rest_enabled           = true
 
 evaka_job_inactive_employees_role_reset_enabled      = false
 evaka_job_send_missing_reservation_reminders_enabled = true

--- a/infra/deploy/variables/nokia-test-apps.tfvars
+++ b/infra/deploy/variables/nokia-test-apps.tfvars
@@ -37,7 +37,6 @@ dvv_modifications_service_xroadclientid       = "FI-TEST/MUN/0205717-4/nokiaevak
 dvv_mutp_update_enabled                       = false
 send_pending_decision_reminder_emails_enabled = true
 evaka_integration_sfi_enabled                 = true
-evaka_integeration_sfi_rest_enabled           = true
 
 evaka_job_inactive_employees_role_reset_enabled      = false
 evaka_job_send_missing_reservation_reminders_enabled = true

--- a/infra/deploy/variables/orivesi-test-apps.tfvars
+++ b/infra/deploy/variables/orivesi-test-apps.tfvars
@@ -37,7 +37,6 @@ dvv_modifications_service_xroadclientid       = "FI-TEST/MUN/0151789-6/orivesiev
 dvv_mutp_update_enabled                       = false
 send_pending_decision_reminder_emails_enabled = true
 evaka_integration_sfi_enabled                 = true
-evaka_integeration_sfi_rest_enabled           = true
 
 evaka_job_inactive_employees_role_reset_enabled      = false
 evaka_job_send_missing_reservation_reminders_enabled = true

--- a/infra/deploy/variables/pirkkala-test-apps.tfvars
+++ b/infra/deploy/variables/pirkkala-test-apps.tfvars
@@ -37,7 +37,6 @@ dvv_modifications_service_xroadclientid       = "FI-TEST/MUN/0152084-1/pirkkalae
 dvv_mutp_update_enabled                       = false
 send_pending_decision_reminder_emails_enabled = true
 evaka_integration_sfi_enabled                 = true
-evaka_integeration_sfi_rest_enabled           = true
 
 evaka_job_inactive_employees_role_reset_enabled      = false
 evaka_job_send_missing_reservation_reminders_enabled = true

--- a/infra/deploy/variables/tampere-dev-apps.tfvars
+++ b/infra/deploy/variables/tampere-dev-apps.tfvars
@@ -48,7 +48,6 @@ dvv_modifications_service_xroadclientid       = "FI-TEST/MUN/0211675-2/treVaka"
 dvv_mutp_update_enabled                       = false
 send_pending_decision_reminder_emails_enabled = true
 evaka_integration_sfi_enabled                 = true
-evaka_integeration_sfi_rest_enabled           = true
 
 evaka_job_freeze_voucher_value_reports_cron          = "0 30 23 L * ?"
 evaka_job_inactive_employees_role_reset_enabled      = false

--- a/infra/deploy/variables/tampere-test-apps.tfvars
+++ b/infra/deploy/variables/tampere-test-apps.tfvars
@@ -51,7 +51,7 @@ email_subject_postfix                         = "staging"
 dvv_modifications_service_xroadclientid       = "FI-TEST/MUN/0211675-2/treVaka"
 dvv_mutp_update_enabled                       = false
 send_pending_decision_reminder_emails_enabled = true
-evaka_integration_sfi_enabled                 = true
+evaka_integration_sfi_enabled                 = false
 
 evaka_job_freeze_voucher_value_reports_cron          = "0 30 23 L * ?"
 evaka_job_inactive_employees_role_reset_enabled      = false

--- a/infra/deploy/variables/vesilahti-test-apps.tfvars
+++ b/infra/deploy/variables/vesilahti-test-apps.tfvars
@@ -44,7 +44,6 @@ dvv_modifications_service_xroadclientid       = "FI-TEST/MUN/0157711-9/vesilahti
 dvv_mutp_update_enabled                       = false
 send_pending_decision_reminder_emails_enabled = true
 evaka_integration_sfi_enabled                 = true
-evaka_integeration_sfi_rest_enabled           = true
 
 evaka_job_inactive_employees_role_reset_enabled      = false
 evaka_job_send_missing_reservation_reminders_enabled = true

--- a/infra/deploy/variables/ylojarvi-test-apps.tfvars
+++ b/infra/deploy/variables/ylojarvi-test-apps.tfvars
@@ -37,7 +37,6 @@ dvv_modifications_service_xroadclientid       = "FI-TEST/MUN/0158221-7/ylojarvie
 dvv_mutp_update_enabled                       = false
 send_pending_decision_reminder_emails_enabled = true
 evaka_integration_sfi_enabled                 = true
-evaka_integeration_sfi_rest_enabled           = true
 
 evaka_job_inactive_employees_role_reset_enabled      = false
 evaka_job_send_missing_reservation_reminders_enabled = true


### PR DESCRIPTION
Also disables the integration in `tampere-test` because we only got one account for each municipality.