### PR TITLE
Update dependabot interval for terraform updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -55,7 +55,7 @@ updates:
   - package-ecosystem: "terraform"
     directory: "/infra/deploy"
     schedule:
-      interval: "daily"
+      interval: "monthly"
       time: "10:00"
       timezone: "Europe/Helsinki"
   - package-ecosystem: "gradle"


### PR DESCRIPTION
We don't need to update terraform providers daily.