### PR TITLE
Remove workaround for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,12 +10,14 @@ updates:
       interval: "daily"
       time: "05:00"
       timezone: "Europe/Helsinki"
-  - package-ecosystem: "docker"
-    directory: "/compose"
+  - package-ecosystem: "docker-compose"
+    directory: "/"
     schedule:
       interval: "daily"
       time: "10:00"
       timezone: "Europe/Helsinki"
+    allow:
+      - dependency-name: "adobe/s3mock"
   - package-ecosystem: "docker"
     directory: "/datadog"
     schedule:

--- a/compose/s3mock.Dockerfile
+++ b/compose/s3mock.Dockerfile
@@ -1,5 +1,0 @@
-# SPDX-FileCopyrightText: 2023-2024 Tampere region
-#
-# SPDX-License-Identifier: LGPL-2.1-or-later
-
-FROM adobe/s3mock:3.12.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,9 +30,7 @@ services:
       retries: 5
 
   s3:
-    build:
-      context: ./compose
-      dockerfile: s3mock.Dockerfile
+    image: adobe/s3mock:3.12.0
     ports:
       - "9091:9090"
       - "9876:9191" # for core tests


### PR DESCRIPTION
It should support docker compose files now:

https://github.blog/changelog/2025-02-25-dependabot-version-updates-now-support-docker-compose-in-general-availability/