### PR TITLE
Enable freeAbsenceGivesADailyRefund (for free summer holiday)

### DIFF
--- a/service/src/main/kotlin/fi/hameenkyro/evaka/HameenkyroConfig.kt
+++ b/service/src/main/kotlin/fi/hameenkyro/evaka/HameenkyroConfig.kt
@@ -36,7 +36,7 @@ class HameenkyroConfig {
         citizenReservationThresholdHours = 7 * 24 - 9, // Mon 09:00
         dailyFeeDivisorOperationalDaysOverride = 20,
         freeSickLeaveOnContractDays = true,
-        freeAbsenceGivesADailyRefund = false,
+        freeAbsenceGivesADailyRefund = true,
         alwaysUseDaycareFinanceDecisionHandler = true,
         paymentNumberSeriesStart = null,
         unplannedAbsencesAreContractSurplusDays = true,

--- a/service/src/main/kotlin/fi/kangasala/evaka/KangasalaConfig.kt
+++ b/service/src/main/kotlin/fi/kangasala/evaka/KangasalaConfig.kt
@@ -36,7 +36,7 @@ class KangasalaConfig {
         citizenReservationThresholdHours = 7 * 24 - 9, // Mon 09:00
         dailyFeeDivisorOperationalDaysOverride = 20,
         freeSickLeaveOnContractDays = true,
-        freeAbsenceGivesADailyRefund = false,
+        freeAbsenceGivesADailyRefund = true,
         alwaysUseDaycareFinanceDecisionHandler = true,
         paymentNumberSeriesStart = null,
         unplannedAbsencesAreContractSurplusDays = true,

--- a/service/src/main/kotlin/fi/lempaala/evaka/LempaalaConfig.kt
+++ b/service/src/main/kotlin/fi/lempaala/evaka/LempaalaConfig.kt
@@ -36,7 +36,7 @@ class LempaalaConfig {
         citizenReservationThresholdHours = (7 + 3) * 24 - 9, // Fri 09:00 (1 week + 3 days before)
         dailyFeeDivisorOperationalDaysOverride = 20,
         freeSickLeaveOnContractDays = true,
-        freeAbsenceGivesADailyRefund = false,
+        freeAbsenceGivesADailyRefund = true,
         alwaysUseDaycareFinanceDecisionHandler = true,
         paymentNumberSeriesStart = null,
         unplannedAbsencesAreContractSurplusDays = true,

--- a/service/src/main/kotlin/fi/nokiankaupunki/evaka/NokiaConfig.kt
+++ b/service/src/main/kotlin/fi/nokiankaupunki/evaka/NokiaConfig.kt
@@ -36,7 +36,7 @@ class NokiaConfig {
         citizenReservationThresholdHours = 7 * 24 - 9, // Mon 09:00
         dailyFeeDivisorOperationalDaysOverride = 20,
         freeSickLeaveOnContractDays = true,
-        freeAbsenceGivesADailyRefund = false,
+        freeAbsenceGivesADailyRefund = true,
         alwaysUseDaycareFinanceDecisionHandler = true,
         paymentNumberSeriesStart = null,
         unplannedAbsencesAreContractSurplusDays = true,

--- a/service/src/main/kotlin/fi/orivesi/evaka/OrivesiConfig.kt
+++ b/service/src/main/kotlin/fi/orivesi/evaka/OrivesiConfig.kt
@@ -36,7 +36,7 @@ class OrivesiConfig {
         citizenReservationThresholdHours = 7 * 24 - 9, // Mon 09:00
         dailyFeeDivisorOperationalDaysOverride = 20,
         freeSickLeaveOnContractDays = true,
-        freeAbsenceGivesADailyRefund = false,
+        freeAbsenceGivesADailyRefund = true,
         alwaysUseDaycareFinanceDecisionHandler = true,
         paymentNumberSeriesStart = null,
         unplannedAbsencesAreContractSurplusDays = true,

--- a/service/src/main/kotlin/fi/pirkkala/evaka/PirkkalaConfig.kt
+++ b/service/src/main/kotlin/fi/pirkkala/evaka/PirkkalaConfig.kt
@@ -36,7 +36,7 @@ class PirkkalaConfig {
         citizenReservationThresholdHours = 7 * 24 - 9, // Mon 09:00
         dailyFeeDivisorOperationalDaysOverride = 20,
         freeSickLeaveOnContractDays = true,
-        freeAbsenceGivesADailyRefund = false,
+        freeAbsenceGivesADailyRefund = true,
         alwaysUseDaycareFinanceDecisionHandler = true,
         paymentNumberSeriesStart = null,
         unplannedAbsencesAreContractSurplusDays = true,

--- a/service/src/main/kotlin/fi/vesilahti/evaka/VesilahtiConfig.kt
+++ b/service/src/main/kotlin/fi/vesilahti/evaka/VesilahtiConfig.kt
@@ -36,7 +36,7 @@ class VesilahtiConfig {
         citizenReservationThresholdHours = 7 * 24 - 9, // Mon 09:00
         dailyFeeDivisorOperationalDaysOverride = 20,
         freeSickLeaveOnContractDays = true,
-        freeAbsenceGivesADailyRefund = false,
+        freeAbsenceGivesADailyRefund = true,
         alwaysUseDaycareFinanceDecisionHandler = true,
         paymentNumberSeriesStart = null,
         unplannedAbsencesAreContractSurplusDays = true,

--- a/service/src/main/kotlin/fi/ylojarvi/evaka/YlojarviConfig.kt
+++ b/service/src/main/kotlin/fi/ylojarvi/evaka/YlojarviConfig.kt
@@ -36,7 +36,7 @@ class YlojarviConfig {
         citizenReservationThresholdHours = 7 * 24 - 9, // Mon 09:00
         dailyFeeDivisorOperationalDaysOverride = 20,
         freeSickLeaveOnContractDays = true,
-        freeAbsenceGivesADailyRefund = false,
+        freeAbsenceGivesADailyRefund = true,
         alwaysUseDaycareFinanceDecisionHandler = true,
         paymentNumberSeriesStart = null,
         unplannedAbsencesAreContractSurplusDays = true,


### PR DESCRIPTION
This should be enough for holiday questionnaire answers to work correctly.

Note: Tampere uses custom logic so this config should still be `false`.