### PR TITLE
Fix password blacklists folder permissions

### DIFF
--- a/service/Dockerfile
+++ b/service/Dockerfile
@@ -33,7 +33,7 @@ ADD --chmod=0755 \
     --checksum=sha256:520ea232e83a7cefe2a87d4f2af8433e383a4351464e213b7dd3b78ca0dc200f \
     https://github.com/espoon-voltti/s3-downloader/releases/download/v1.4.1/s3downloader-linux-amd64 \
     /usr/local/bin/s3download
-ADD --chmod=0644 \
+ADD --chmod=u=rwX,go=rX \
     --checksum=sha256:424a3e03a17df0a2bc2b3ca749d81b04e79d59cb7aeec8876a5a3f308d0caf51 \
     https://raw.githubusercontent.com/danielmiessler/SecLists/2023.1/Passwords/xato-net-10-million-passwords-1000000.txt \
     /opt/password-blacklists/xato-net-10-million-passwords-1000000.txt


### PR DESCRIPTION
Fixes error `java.io.FileNotFoundException: /opt/password-blacklists/xato-net-10-million-passwords-1000000.txt (Permission denied)`.