### PR TITLE
Update service .dockerignore

### DIFF
--- a/service/.dockerignore
+++ b/service/.dockerignore
@@ -2,6 +2,13 @@
 #
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-.gradle/
-.idea/
-build/
+*
+!gradle/
+!src/
+!.editorconfig
+!build.gradle.kts
+!entrypoint.sh
+!gradle.properties
+!gradlew
+!settings.gradle.kts
+!settings-dependabot-ignore.gradle.kts


### PR DESCRIPTION
e.g. `Dockerfile` edit doesn't always require full build now.