### PR TITLE
Add docker buildx inspect

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ commands:
     steps:
       - run:
           name: Create docker builder instance
-          command: docker buildx inspect trevaka || docker buildx create --driver=docker-container --name trevaka --use
+          command: docker buildx inspect trevaka || docker buildx create --driver=docker-container --name trevaka --bootstrap --use && docker buildx inspect trevaka
       - run:
           name: Build docker image
           command: |


### PR DESCRIPTION
Before:
```
ERROR: no builder "trevaka" found
Name:          trevaka
```

After also this is printed:
```
Name:          trevaka
Driver:        docker-container
Last Activity: 2025-05-23 08:11:07 +0000 UTC

Nodes:
Name:                  trevaka0
Endpoint:              unix:///var/run/docker.sock
Status:                running
BuildKit daemon flags: --allow-insecure-entitlement=network.host
BuildKit version:      v0.21.1
Platforms:             linux/amd64, linux/amd64/v2, linux/amd64/v3, linux/amd64/v4, linux/386
...
```

Especially `BuildKit version` might help debugging.