### PR TITLE
Add reuse-tool to mise

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -10,6 +10,8 @@ idiomatic_version_file_enable_tools = ["terraform"]
 [tools]
 java = "temurin-21"
 node = { version = "22", postinstall = "corepack enable" }
+python = "3.13"
+"pipx:reuse" = "5.0.2"
 
 [env]
 NODE_OPTIONS = "--max-old-space-size=8192"


### PR DESCRIPTION
Upstream script `evaka/bin/add-license-headers.sh` requires `reuse` command.