### PR TITLE
Update Tampere assistance action options

### DIFF
--- a/service/src/main/resources/db/data/tampere/afterMigrate__assistance_action_options.sql
+++ b/service/src/main/resources/db/data/tampere/afterMigrate__assistance_action_options.sql
@@ -19,12 +19,12 @@ VALUES
 
     ('35', 'Esiopetuksen erityisryhmä', NULL, 210, 'PRESCHOOL', NULL, NULL),
     ('55', 'Integroitu esiopetusryhmä', 'Lapsi on integroidussa esiopetusryhmässä.', 200, 'PRESCHOOL', NULL, NULL),
-    ('200', 'Erho', NULL, 220, 'PRESCHOOL', '2025-08-01'::date, NULL),
+    ('200', 'Erho', NULL, 220, 'PRESCHOOL', NULL, NULL),
     ('210', 'Erityisopettajan antama opetus muun opetuksen yhteydessä', 'Ryhmäkohtainen tukimuoto', 230, 'PRESCHOOL', '2025-08-01'::date, NULL),
     ('220', 'Säännöllinen erityisopettajan antama opetus osittain pienryhmässä ja muun opetuksen yhteydessä', 'Lapsikohtainen tukitoimi', 240, 'PRESCHOOL', '2025-08-01'::date, NULL),
     ('230', 'Kokoaikainen erityisopettajan antama opetus pienryhmässä', 'Lapsikohtainen tukitoimi', 240, 'PRESCHOOL', '2025-08-01'::date, NULL),
     ('240', 'Lapsikohtainen avustaja', 'Lapsikohtainen tukitoimi', 250, 'PRESCHOOL', '2025-08-01'::date, NULL),
-    ('250', 'Tulkitsemispalvelut', 'Lapsikohtainen tukitoimi', 260, 'PRESCHOOL', '2025-08-01'::date, NULL),
+    ('250', 'Tulkitsemispalvelut', 'Lapsikohtainen tukitoimi', 260, 'PRESCHOOL', NULL, NULL),
     ('260', 'Apuvälineet', 'Lapsikohtainen tukitoimi', 270, 'PRESCHOOL', '2025-08-01'::date, NULL)
 
 
@@ -39,7 +39,7 @@ UPDATE SET
 WHERE
     assistance_action_option.name_fi <> EXCLUDED.name_fi OR
     assistance_action_option.description_fi IS DISTINCT FROM EXCLUDED.description_fi OR
-    assistance_action_option.display_order <> EXCLUDED.display_order OR
+    assistance_action_option.display_order IS DISTINCT FROM EXCLUDED.display_order OR
     assistance_action_option.category <> EXCLUDED.category OR
-    assistance_action_option.valid_from <> EXCLUDED.valid_from OR
-    assistance_action_option.valid_to <> EXCLUDED.valid_to;
+    assistance_action_option.valid_from IS DISTINCT FROM EXCLUDED.valid_from OR
+    assistance_action_option.valid_to IS DISTINCT FROM EXCLUDED.valid_to;

--- a/service/src/main/resources/db/data/tampere/afterMigrate__assistance_action_options.sql
+++ b/service/src/main/resources/db/data/tampere/afterMigrate__assistance_action_options.sql
@@ -3,28 +3,43 @@
 -- SPDX-License-Identifier: LGPL-2.1-or-later
 
 INSERT INTO assistance_action_option
-    (value, name_fi, description_fi, display_order, category)
+    (value, name_fi, description_fi, display_order, category, valid_from, valid_to)
 VALUES
-    ('10', 'Avustajapalvelut', 'Lapsen ryhmässä työskentelee ryhmäavustaja tai lapsella on henkilökohtainen avustaja.', 80, 'DAYCARE'),
-    ('20', 'Erho', NULL, 110, 'DAYCARE'),
-    ('30', 'Varhaiskasvatuksen erityisryhmä', 'Lapsi on erityisryhmässä.', 10, 'DAYCARE'),
-    ('35', 'Esiopetuksen erityisryhmä', NULL, 20, 'DAYCARE'),
-    ('40', 'Henkilökuntalisäys tai -muutos', 'Henkilökuntalisäys: Lapsen ryhmässä työskentelee lain vaatimaan resurssia enemmän varhaiskasvatuksen lastenhoitajia/sosionomeja/opettajia. Henkilökuntamuutos: Ryhmää on vahvistettu pedagogisesti siten, että henkilöstöön kuuluu kaksi varhaiskasvatuksen opettajaa. Mikäli lapsi on erityisryhmässä tai integroidussa ryhmässä, tätä vaihtoehtoa ei valita.', 90, 'DAYCARE'),
-    ('50', 'Integroitu varhaiskasvatusryhmä', 'Lapsi on integroidussa varhaiskasvatusryhmässä.', 30, 'DAYCARE'),
-    ('55', 'Integroitu esiopetusryhmä', 'Lapsi on integroidussa esiopetusryhmässä.', 40, 'DAYCARE'),
-    ('57', 'Kokoaikainen erityisopetus', 'Lapsen ryhmässä työskentelee yhtenä työntekijänä varhaiskasvatuksen erityisopettaja.', 50, 'DAYCARE'),
-    ('60', 'Osa-aikainen erityisopetus', 'Lapsi saa osa-aikaista erityisopetusta.', 60, 'DAYCARE'),
-    ('70', 'Erityisopettajan konsultaatio', 'Lapsen ryhmän henkilökunta saa erityisopettajan konsultaatiota.', 70, 'DAYCARE'),
-    ('80', 'Tulkitsemispalvelut', 'Lapsi saa tulkitsemispalveluita kuulo- ja/tai näkövammansa vuoksi. Huoltajien kanssa käytettävät tulkkipalvelut eivät sisälly tähän.', 120, 'DAYCARE'),
-    ('100', 'Ryhmän pienennys', 'Ryhmän pienennys rakenteellisen tuen muotona eli lapsiryhmää pienennetään, jotta lasten tuki toteutuu tarkoituksenmukaisesti. Kirjaa myös tuen kerroin kohtaan Tuen tarve.', 100, 'DAYCARE')
+    ('10', 'Avustajapalvelut', 'Lapsen ryhmässä työskentelee ryhmäavustaja tai lapsella on henkilökohtainen avustaja.', 40, 'DAYCARE', NULL, NULL),
+    ('20', 'Erho-yksikkö', NULL, 30, 'DAYCARE', NULL, NULL),
+    ('30', 'Varhaiskasvatuksen erityisryhmä', 'Lapsi on erityisryhmässä.', 20, 'DAYCARE', NULL, NULL),
+    ('40', 'Henkilökuntalisäys tai -muutos', 'Henkilökuntalisäys: Lapsen ryhmässä työskentelee lain vaatimaan resurssia enemmän varhaiskasvatuksen lastenhoitajia/sosionomeja/opettajia. Henkilökuntamuutos: Ryhmää on vahvistettu pedagogisesti siten, että henkilöstöön kuuluu kaksi varhaiskasvatuksen opettajaa. Mikäli lapsi on erityisryhmässä tai integroidussa ryhmässä, tätä vaihtoehtoa ei valita.', 60, 'DAYCARE', NULL, NULL),
+    ('50', 'Integroitu varhaiskasvatusryhmä', 'Lapsi on integroidussa varhaiskasvatusryhmässä.', 10, 'DAYCARE', NULL, NULL),
+    ('57', 'Kokoaikainen erityisopetus', 'Lapsen ryhmässä työskentelee yhtenä työntekijänä varhaiskasvatuksen erityisopettaja.', 90, 'DAYCARE', NULL, NULL),
+    ('60', 'Osa-aikainen erityisopetus', 'Lapsi saa osa-aikaista erityisopetusta.', 80, 'DAYCARE', NULL, NULL),
+    ('70', 'Erityisopettajan konsultaatio', 'Lapsen ryhmän henkilökunta saa erityisopettajan konsultaatiota.', 70, 'DAYCARE', NULL, NULL),
+    ('80', 'Tulkitsemispalvelut', 'Lapsi saa tulkitsemispalveluita kuulo- ja/tai näkövammansa vuoksi. Huoltajien kanssa käytettävät tulkkipalvelut eivät sisälly tähän.', 100, 'DAYCARE', NULL, NULL),
+    ('100', 'Ryhmäkoon pienennys', 'Ryhmän pienennys rakenteellisen tuen muotona eli lapsiryhmää pienennetään, jotta lasten tuki toteutuu tarkoituksenmukaisesti. Kirjaa myös tuen kerroin kohtaan Tuen tarve.', 50, 'DAYCARE', NULL, NULL),
+    ('110', 'Apuvälineet', NULL, 110, 'DAYCARE', '2025-08-01'::date, NULL),
+
+    ('35', 'Esiopetuksen erityisryhmä', NULL, 210, 'PRESCHOOL', NULL, NULL),
+    ('55', 'Integroitu esiopetusryhmä', 'Lapsi on integroidussa esiopetusryhmässä.', 200, 'PRESCHOOL', NULL, NULL),
+    ('200', 'Erho', NULL, 220, 'PRESCHOOL', '2025-08-01'::date, NULL),
+    ('210', 'Erityisopettajan antama opetus muun opetuksen yhteydessä', 'Ryhmäkohtainen tukimuoto', 230, 'PRESCHOOL', '2025-08-01'::date, NULL),
+    ('220', 'Säännöllinen erityisopettajan antama opetus osittain pienryhmässä ja muun opetuksen yhteydessä', 'Lapsikohtainen tukitoimi', 240, 'PRESCHOOL', '2025-08-01'::date, NULL),
+    ('230', 'Kokoaikainen erityisopettajan antama opetus pienryhmässä', 'Lapsikohtainen tukitoimi', 240, 'PRESCHOOL', '2025-08-01'::date, NULL),
+    ('240', 'Lapsikohtainen avustaja', 'Lapsikohtainen tukitoimi', 250, 'PRESCHOOL', '2025-08-01'::date, NULL),
+    ('250', 'Tulkitsemispalvelut', 'Lapsikohtainen tukitoimi', 260, 'PRESCHOOL', '2025-08-01'::date, NULL),
+    ('260', 'Apuvälineet', 'Lapsikohtainen tukitoimi', 270, 'PRESCHOOL', '2025-08-01'::date, NULL)
+
+
 ON CONFLICT (value) DO
 UPDATE SET
     name_fi = EXCLUDED.name_fi,
     description_fi = EXCLUDED.description_fi,
     display_order = EXCLUDED.display_order,
-    category = EXCLUDED.category
+    category = EXCLUDED.category,
+    valid_from = EXCLUDED.valid_from,
+    valid_to = EXCLUDED.valid_to
 WHERE
     assistance_action_option.name_fi <> EXCLUDED.name_fi OR
     assistance_action_option.description_fi IS DISTINCT FROM EXCLUDED.description_fi OR
     assistance_action_option.display_order <> EXCLUDED.display_order OR
-    assistance_action_option.category <> EXCLUDED.category;
+    assistance_action_option.category <> EXCLUDED.category OR
+    assistance_action_option.valid_from <> EXCLUDED.valid_from OR
+    assistance_action_option.valid_to <> EXCLUDED.valid_to;


### PR DESCRIPTION
Adds 
- 1 `DAYCARE` option 
- 7 `PRESCHOOL` options. 

Moves 2 `DAYCARE` options to `PRESCHOOL`. 
Changes names of 2 `DAYCARE` options slightly.

New options have `valid_from` dates, old ones don't.