### PR TITLE
Tampere region municipality update for assistance action options

### DIFF
--- a/service/src/main/resources/db/data/hameenkyro/afterMigrate__assistance_action_options.sql
+++ b/service/src/main/resources/db/data/hameenkyro/afterMigrate__assistance_action_options.sql
@@ -3,22 +3,35 @@
 -- SPDX-License-Identifier: LGPL-2.1-or-later
 
 INSERT INTO assistance_action_option
-    (value, name_fi, description_fi, display_order, category)
+    (value, name_fi, description_fi, display_order, category, valid_from, valid_to)
 VALUES
-    ('10', 'Avustajapalvelut', 'Lapsen ryhmässä työskentelee ryhmäavustaja tai lapsella on henkilökohtainen avustaja.', 30, 'DAYCARE'),
-    ('40', 'Henkilökuntalisäys tai -muutos', 'Henkilökuntalisäys: Lapsen ryhmässä työskentelee lain vaatimaan resurssia enemmän varhaiskasvatuksen lastenhoitajia/sosionomeja/opettajia. Henkilökuntamuutos: Ryhmää on vahvistettu pedagogisesti siten, että henkilöstöön kuuluu kaksi varhaiskasvatuksen opettajaa. Mikäli lapsi on erityisryhmässä tai integroidussa ryhmässä, tätä vaihtoehtoa ei valita.', 40, 'DAYCARE'),
-    ('60', 'Osa-aikainen erityisopetus', 'Lapsi saa osa-aikaista erityisopetusta.', 10, 'DAYCARE'),
-    ('70', 'Erityisopettajan konsultaatio', 'Lapsen ryhmän henkilökunta saa erityisopettajan konsultaatiota.', 20, 'DAYCARE'),
-    ('80', 'Tulkitsemispalvelut', 'Lapsi saa tulkitsemispalveluita kuulo- ja/tai näkövammansa vuoksi. Huoltajien kanssa käytettävät tulkkipalvelut eivät sisälly tähän.', 60, 'DAYCARE'),
-    ('100', 'Ryhmän pienennys', 'Ryhmän pienennys rakenteellisen tuen muotona eli lapsiryhmää pienennetään, jotta lasten tuki toteutuu tarkoituksenmukaisesti. Kirjaa myös tuen kerroin kohtaan Tuen tarve.', 50, 'DAYCARE')
+    ('10', 'Avustajapalvelut', 'Lapsen ryhmässä työskentelee ryhmäavustaja tai lapsella on henkilökohtainen avustaja.', 30, 'DAYCARE', NULL, NULL),
+    ('40', 'Henkilökuntalisäys tai -muutos', 'Henkilökuntalisäys: Lapsen ryhmässä työskentelee lain vaatimaan resurssia enemmän varhaiskasvatuksen lastenhoitajia/sosionomeja/opettajia. Henkilökuntamuutos: Ryhmää on vahvistettu pedagogisesti siten, että henkilöstöön kuuluu kaksi varhaiskasvatuksen opettajaa. Mikäli lapsi on erityisryhmässä tai integroidussa ryhmässä, tätä vaihtoehtoa ei valita.', 40, 'DAYCARE', NULL, NULL),
+    ('60', 'Osa-aikainen erityisopetus', 'Lapsi saa osa-aikaista erityisopetusta.', 10, 'DAYCARE', NULL, NULL),
+    ('65', 'Kokoaikainen erityisopetus', NULL, 15, 'DAYCARE', '2025-08-01'::date, NULL),
+    ('70', 'Erityisopettajan konsultaatio', 'Lapsen ryhmän henkilökunta saa erityisopettajan konsultaatiota.', 20, 'DAYCARE', NULL, NULL),
+    ('80', 'Tulkitsemispalvelut', 'Lapsi saa tulkitsemispalveluita kuulo- ja/tai näkövammansa vuoksi. Huoltajien kanssa käytettävät tulkkipalvelut eivät sisälly tähän.', 60, 'DAYCARE', NULL, NULL),
+    ('100', 'Ryhmän pienennys', 'Ryhmän pienennys rakenteellisen tuen muotona eli lapsiryhmää pienennetään, jotta lasten tuki toteutuu tarkoituksenmukaisesti. Kirjaa myös tuen kerroin kohtaan Tuen tarve.', 50, 'DAYCARE', NULL, NULL),
+
+    ('200', 'Kokoaikainen erityisopettajan antama opetus pienryhmässä', NULL, 200, 'PRESCHOOL', '2025-08-01'::date, NULL),
+    ('210', 'Säännöllinen erityisopettajan antama opetus osittain pienryhmässä ja muun opetuksen yhteydessä', NULL, 210, 'PRESCHOOL', '2025-08-01'::date, NULL),
+    ('220', 'Erityisopettajan antamaopetus muun opetuksen yhteydessä', NULL, 220, 'PRESCHOOL', '2025-08-01'::date, NULL),
+    ('230', 'Avustajapalvelut', 'Lapsen ryhmässä työskentelee ryhmäavustaja tai lapsella on henkilökohtainen avustaja.', 230, 'PRESCHOOL', NULL, NULL),
+    ('240', 'Apuvälineet', NULL, 240, 'PRESCHOOL', '2025-08-01'::date, NULL),
+    ('250', 'Lapsikohtaiset tukitoimet', NULL, 250, 'PRESCHOOL', '2025-08-01'::date, NULL),
+    ('260', 'Tulkitsemispalvelut', 'Lapsi saa tulkitsemispalveluita kuulo- ja/tai näkövammansa vuoksi. Huoltajien kanssa käytettävät tulkkipalvelut eivät sisälly tähän.', 260, 'PRESCHOOL', NULL, NULL)
 ON CONFLICT (value) DO
 UPDATE SET
     name_fi = EXCLUDED.name_fi,
     description_fi = EXCLUDED.description_fi,
     display_order = EXCLUDED.display_order,
-    category = EXCLUDED.category
+    category = EXCLUDED.category,
+    valid_from = EXCLUDED.valid_from,
+    valid_to = EXCLUDED.valid_to
 WHERE
     assistance_action_option.name_fi <> EXCLUDED.name_fi OR
     assistance_action_option.description_fi IS DISTINCT FROM EXCLUDED.description_fi OR
-    assistance_action_option.display_order <> EXCLUDED.display_order OR
-    assistance_action_option.category <> EXCLUDED.category;
+    assistance_action_option.display_order IS DISTINCT FROM EXCLUDED.display_order OR
+    assistance_action_option.category <> EXCLUDED.category OR
+    assistance_action_option.valid_from IS DISTINCT FROM EXCLUDED.valid_from OR
+    assistance_action_option.valid_to IS DISTINCT FROM EXCLUDED.valid_to;

--- a/service/src/main/resources/db/data/kangasala/afterMigrate__assistance_action_options.sql
+++ b/service/src/main/resources/db/data/kangasala/afterMigrate__assistance_action_options.sql
@@ -3,26 +3,41 @@
 -- SPDX-License-Identifier: LGPL-2.1-or-later
 
 INSERT INTO assistance_action_option
-    (value, name_fi, description_fi, display_order, category)
+    (value, name_fi, description_fi, display_order, category, valid_from, valid_to)
 VALUES
-    ('10', 'Avustajapalvelut', 'Lapsen ryhmässä työskentelee ryhmäavustaja tai lapsella on henkilökohtainen avustaja.', 80, 'DAYCARE'),
-    ('20', 'Erho', NULL, 110, 'DAYCARE'),
-    ('40', 'Henkilökuntalisäys tai -muutos', 'Henkilökuntalisäys: Lapsen ryhmässä työskentelee lain vaatimaan resurssia enemmän varhaiskasvatuksen lastenhoitajia/sosionomeja/opettajia. Henkilökuntamuutos: Ryhmää on vahvistettu pedagogisesti siten, että henkilöstöön kuuluu kaksi varhaiskasvatuksen opettajaa. Mikäli lapsi on erityisryhmässä tai integroidussa ryhmässä, tätä vaihtoehtoa ei valita.', 90, 'DAYCARE'),
-    ('50', 'Integroitu varhaiskasvatusryhmä', 'Lapsi on integroidussa varhaiskasvatusryhmässä.', 30, 'DAYCARE'),
-    ('55', 'Integroitu esiopetusryhmä', 'Lapsi on integroidussa esiopetusryhmässä.', 40, 'DAYCARE'),
-    ('57', 'Kokoaikainen erityisopetus', 'Lapsen ryhmässä työskentelee yhtenä työntekijänä varhaiskasvatuksen erityisopettaja.', 50, 'DAYCARE'),
-    ('60', 'Osa-aikainen erityisopetus', 'Lapsi saa osa-aikaista erityisopetusta.', 60, 'DAYCARE'),
-    ('70', 'Erityisopettajan konsultaatio', 'Lapsen ryhmän henkilökunta saa erityisopettajan konsultaatiota.', 70, 'DAYCARE'),
-    ('80', 'Tulkitsemispalvelut', 'Lapsi saa tulkitsemispalveluita kuulo- ja/tai näkövammansa vuoksi. Huoltajien kanssa käytettävät tulkkipalvelut eivät sisälly tähän.', 120, 'DAYCARE'),
-    ('100', 'Ryhmän pienennys', 'Ryhmän pienennys rakenteellisen tuen muotona eli lapsiryhmää pienennetään, jotta lasten tuki toteutuu tarkoituksenmukaisesti. Kirjaa myös tuen kerroin kohtaan Tuen tarve.', 100, 'DAYCARE')
+    ('10', 'Avustajapalvelut', 'Lapsen ryhmässä työskentelee ryhmäavustaja tai lapsella on henkilökohtainen avustaja.', 80, 'DAYCARE', NULL, NULL),
+    ('40', 'Henkilökuntalisäys tai -muutos', 'Henkilökuntalisäys: Lapsen ryhmässä työskentelee lain vaatimaan resurssia enemmän varhaiskasvatuksen lastenhoitajia/sosionomeja/opettajia. Henkilökuntamuutos: Ryhmää on vahvistettu pedagogisesti siten, että henkilöstöön kuuluu kaksi varhaiskasvatuksen opettajaa. Mikäli lapsi on erityisryhmässä tai integroidussa ryhmässä, tätä vaihtoehtoa ei valita.', 90, 'DAYCARE', NULL, NULL),
+    ('50', 'Integroitu varhaiskasvatusryhmä', 'Lapsi on integroidussa varhaiskasvatusryhmässä.', 30, 'DAYCARE', NULL, NULL),
+    ('57', 'Kokoaikainen erityisopetus', 'Lapsen ryhmässä työskentelee yhtenä työntekijänä varhaiskasvatuksen erityisopettaja.', 50, 'DAYCARE', NULL, NULL),
+    ('60', 'Osa-aikainen erityisopetus', 'Lapsi saa osa-aikaista erityisopetusta.', 60, 'DAYCARE', NULL, NULL),
+    ('70', 'Erityisopettajan konsultaatio', 'Lapsen ryhmän henkilökunta saa erityisopettajan konsultaatiota.', 70, 'DAYCARE', NULL, NULL),
+    ('80', 'Tulkitsemispalvelut', 'Lapsi saa tulkitsemispalveluita kuulo- ja/tai näkövammansa vuoksi. Huoltajien kanssa käytettävät tulkkipalvelut eivät sisälly tähän.', 120, 'DAYCARE', NULL, NULL),
+    ('100', 'Ryhmän pienennys', 'Ryhmän pienennys rakenteellisen tuen muotona eli lapsiryhmää pienennetään, jotta lasten tuki toteutuu tarkoituksenmukaisesti. Kirjaa myös tuen kerroin kohtaan Tuen tarve.', 100, 'DAYCARE', NULL, NULL),
+
+    -- ended DAYCARE
+    ('20', 'Erho', NULL, 110, 'DAYCARE', NULL, '2025-07-31'::date),
+
+    ('55', 'Integroitu esiopetusryhmä', 'Lapsi on integroidussa esiopetusryhmässä.', 200, 'PRESCHOOL', NULL, NULL),
+    ('200', 'Esiopetuksen erityisryhmä', NULL, 210, 'PRESCHOOL', '2025-08-01'::date, NULL),
+    ('210', 'Erityisopettajan antama opetus muun opetuksen yhteydessä', NULL, 220, 'PRESCHOOL', '2025-08-01'::date, NULL),
+    ('220', 'Säännöllinen erityisopettajan antama opetus osittain pienryhmässä ja muun opetuksen yhteydessä ', NULL, 230, 'PRESCHOOL', '2025-08-01'::date, NULL),
+    ('230', 'Kokoaikainen erityisopettajan antama opetus pienryhmässä ', NULL, 240, 'PRESCHOOL', '2025-08-01'::date, NULL),
+    ('240', 'Lapsikohtainen avustaja', NULL, 250, 'PRESCHOOL', '2025-08-01'::date, NULL),
+    ('250', 'Tulkitsemispalvelut', 'Lapsi saa tulkitsemispalveluita kuulo- ja/tai näkövammansa vuoksi. Huoltajien kanssa käytettävät tulkkipalvelut eivät sisälly tähän.', 260, 'PRESCHOOL', NULL, NULL),
+    ('260', 'Apuvälineet', NULL, 270, 'PRESCHOOL', '2025-08-01'::date, NULL)
+
 ON CONFLICT (value) DO
 UPDATE SET
     name_fi = EXCLUDED.name_fi,
     description_fi = EXCLUDED.description_fi,
     display_order = EXCLUDED.display_order,
-    category = EXCLUDED.category
+    category = EXCLUDED.category,
+    valid_from = EXCLUDED.valid_from,
+    valid_to = EXCLUDED.valid_to
 WHERE
     assistance_action_option.name_fi <> EXCLUDED.name_fi OR
     assistance_action_option.description_fi IS DISTINCT FROM EXCLUDED.description_fi OR
-    assistance_action_option.display_order <> EXCLUDED.display_order OR
-    assistance_action_option.category <> EXCLUDED.category;
+    assistance_action_option.display_order IS DISTINCT FROM EXCLUDED.display_order OR
+    assistance_action_option.category <> EXCLUDED.category OR
+    assistance_action_option.valid_from IS DISTINCT FROM EXCLUDED.valid_from OR
+    assistance_action_option.valid_to IS DISTINCT FROM EXCLUDED.valid_to;

--- a/service/src/main/resources/db/data/nokia/afterMigrate__assistance_action_options.sql
+++ b/service/src/main/resources/db/data/nokia/afterMigrate__assistance_action_options.sql
@@ -3,24 +3,37 @@
 -- SPDX-License-Identifier: LGPL-2.1-or-later
 
 INSERT INTO assistance_action_option
-    (value, name_fi, description_fi, display_order, category)
+    (value, name_fi, description_fi, display_order, category, valid_from, valid_to)
 VALUES
-    ('10', 'Avustajapalvelut', 'Lapsen ryhmässä työskentelee ryhmäavustaja tai lapsella on henkilökohtainen avustaja.', 80, 'DAYCARE'),
-    ('20', 'Erho', NULL, 110, 'DAYCARE'),
-    ('40', 'Henkilökuntalisäys tai -muutos', 'Henkilökuntalisäys: Lapsen ryhmässä työskentelee lain vaatimaan resurssia enemmän varhaiskasvatuksen lastenhoitajia/sosionomeja/opettajia. Henkilökuntamuutos: Ryhmää on vahvistettu pedagogisesti siten, että henkilöstöön kuuluu kaksi varhaiskasvatuksen opettajaa. Mikäli lapsi on erityisryhmässä tai integroidussa ryhmässä, tätä vaihtoehtoa ei valita.', 90, 'DAYCARE'),
-    ('57', 'Kokoaikainen erityisopetus', 'Lapsen ryhmässä työskentelee yhtenä työntekijänä varhaiskasvatuksen erityisopettaja.', 50, 'DAYCARE'),
-    ('60', 'Osa-aikainen erityisopetus', 'Lapsi saa osa-aikaista erityisopetusta.', 60, 'DAYCARE'),
-    ('70', 'Erityisopettajan konsultaatio', 'Lapsen ryhmän henkilökunta saa erityisopettajan konsultaatiota.', 70, 'DAYCARE'),
-    ('80', 'Tulkitsemispalvelut', 'Lapsi saa tulkitsemispalveluita kuulo- ja/tai näkövammansa vuoksi. Huoltajien kanssa käytettävät tulkkipalvelut eivät sisälly tähän.', 120, 'DAYCARE'),
-    ('100', 'Ryhmän pienennys', 'Ryhmän pienennys rakenteellisen tuen muotona eli lapsiryhmää pienennetään, jotta lasten tuki toteutuu tarkoituksenmukaisesti. Kirjaa myös tuen kerroin kohtaan Tuen tarve.', 100, 'DAYCARE')
+    ('10', 'Avustajapalvelut', 'Lapsen ryhmässä työskentelee ryhmäavustaja tai lapsella on henkilökohtainen avustaja.', 80, 'DAYCARE', NULL, NULL),
+    ('20', 'Erho', NULL, 110, 'DAYCARE', NULL, NULL),
+    ('40', 'Henkilökuntalisäys tai -muutos', 'Henkilökuntalisäys: Lapsen ryhmässä työskentelee lain vaatimaan resurssia enemmän varhaiskasvatuksen lastenhoitajia/sosionomeja/opettajia. Henkilökuntamuutos: Ryhmää on vahvistettu pedagogisesti siten, että henkilöstöön kuuluu kaksi varhaiskasvatuksen opettajaa. Mikäli lapsi on erityisryhmässä tai integroidussa ryhmässä, tätä vaihtoehtoa ei valita.', 90, 'DAYCARE', NULL, NULL),
+    ('57', 'Kokoaikainen erityisopetus', 'Lapsen ryhmässä työskentelee yhtenä työntekijänä varhaiskasvatuksen erityisopettaja.', 50, 'DAYCARE', NULL, NULL),
+    ('60', 'Osa-aikainen erityisopetus', 'Lapsi saa osa-aikaista erityisopetusta.', 60, 'DAYCARE', NULL, NULL),
+    ('70', 'Erityisopettajan konsultaatio', 'Lapsen ryhmän henkilökunta saa erityisopettajan konsultaatiota.', 70, 'DAYCARE', NULL, NULL),
+    ('80', 'Tulkitsemispalvelut', 'Lapsi saa tulkitsemispalveluita kuulo- ja/tai näkövammansa vuoksi. Huoltajien kanssa käytettävät tulkkipalvelut eivät sisälly tähän.', 120, 'DAYCARE', NULL, NULL),
+    ('100', 'Ryhmän pienennys', 'Ryhmän pienennys rakenteellisen tuen muotona eli lapsiryhmää pienennetään, jotta lasten tuki toteutuu tarkoituksenmukaisesti. Kirjaa myös tuen kerroin kohtaan Tuen tarve.', 100, 'DAYCARE', NULL, NULL),
+
+    ('200', 'Ryhmän pienennys', 'Ryhmän pienennys rakenteellisen tuen muotona eli lapsiryhmää pienennetään, jotta lasten tuki toteutuu tarkoituksenmukaisesti. Kirjaa myös tuen kerroin kohtaan Tuen tarve.', 200, 'PRESCHOOL', NULL, NULL),
+    ('210', 'Erityisopettajan antama opetus osittain pienryhmässä ja muun opetuksen yhteydessä ', NULL, 210, 'PRESCHOOL', '2025-08-01'::date, NULL),
+    ('220', 'Tulkitsemispalvelut', 'Lapsi saa tulkitsemispalveluita kuulo- ja/tai näkövammansa vuoksi. Huoltajien kanssa käytettävät tulkkipalvelut eivät sisälly tähän.', 220, 'PRESCHOOL', NULL, NULL),
+    ('230', 'Avustajapalvelut', 'Lapsen ryhmässä työskentelee ryhmäavustaja tai lapsella on henkilökohtainen avustaja.', 230, 'PRESCHOOL', NULL, NULL),
+    ('240', 'Apuvälineet', NULL, 240, 'PRESCHOOL', '2025-08-01'::date, NULL),
+    ('250', 'Erityisopettajan antama opetus pienryhmässä (kokoaikainen)', NULL, 250, 'PRESCHOOL', '2025-08-01'::date, NULL),
+    ('260', 'Erho', NULL, 260, 'PRESCHOOL', NULL, NULL)
+
 ON CONFLICT (value) DO
 UPDATE SET
     name_fi = EXCLUDED.name_fi,
     description_fi = EXCLUDED.description_fi,
     display_order = EXCLUDED.display_order,
-    category = EXCLUDED.category
+    category = EXCLUDED.category,
+    valid_from = EXCLUDED.valid_from,
+    valid_to = EXCLUDED.valid_to
 WHERE
     assistance_action_option.name_fi <> EXCLUDED.name_fi OR
     assistance_action_option.description_fi IS DISTINCT FROM EXCLUDED.description_fi OR
-    assistance_action_option.display_order <> EXCLUDED.display_order OR
-    assistance_action_option.category <> EXCLUDED.category;
+    assistance_action_option.display_order IS DISTINCT FROM EXCLUDED.display_order OR
+    assistance_action_option.category <> EXCLUDED.category OR
+    assistance_action_option.valid_from IS DISTINCT FROM EXCLUDED.valid_from OR
+    assistance_action_option.valid_to IS DISTINCT FROM EXCLUDED.valid_to;

--- a/service/src/main/resources/db/data/ylojarvi/afterMigrate__assistance_action_options.sql
+++ b/service/src/main/resources/db/data/ylojarvi/afterMigrate__assistance_action_options.sql
@@ -3,23 +3,44 @@
 -- SPDX-License-Identifier: LGPL-2.1-or-later
 
 INSERT INTO assistance_action_option
-    (value, name_fi, description_fi, display_order, category)
+    (value, name_fi, description_fi, display_order, category, valid_from, valid_to)
 VALUES
-    ('10', 'Avustajapalvelut', 'Lapsen ryhmässä työskentelee ryhmäavustaja tai lapsella on henkilökohtainen avustaja.', 80, 'DAYCARE'),
-    ('40', 'Henkilökuntalisäys tai -muutos', 'Henkilökuntalisäys: Lapsen ryhmässä työskentelee lain vaatimaan resurssia enemmän varhaiskasvatuksen lastenhoitajia/sosionomeja/opettajia. Henkilökuntamuutos: Ryhmää on vahvistettu pedagogisesti siten, että henkilöstöön kuuluu kaksi varhaiskasvatuksen opettajaa. Mikäli lapsi on erityisryhmässä tai integroidussa ryhmässä, tätä vaihtoehtoa ei valita.', 90, 'DAYCARE'),
-    ('50', 'Tuettu varhaiskasvatusryhmä', 'Lapsi on tuetussa varhaiskasvatusryhmässä.', 30, 'DAYCARE'),
-    ('55', 'Tuettu esiopetusryhmä', 'Lapsi on tuetussa esiopetusryhmässä.', 40, 'DAYCARE'),
-    ('57', 'Vaativan erityisen tuen varhaiskasvatusryhmä', 'Lapsen ryhmässä työskentelee yhtenä työntekijänä varhaiskasvatuksen erityisopettaja.', 50, 'DAYCARE'),
-    ('60', 'Vaativan erityisen tuen perusopetuksen ryhmä/esiopetus', 'Lapsi saa osa-aikaista erityisopetusta.', 60, 'DAYCARE'),
-    ('70', 'Erityisopettajan antama säännöllinen tuki', 'Ryhmän pienennys rakenteellisen tuen muotona eli lapsiryhmää pienennetään, jotta lasten tuki toteutuu tarkoituksenmukaisesti. Kirjaa myös tuen kerroin kohtaan Tuen tarve.', 70, 'DAYCARE')
+    ('10', 'Avustajapalvelut', 'Lapsen ryhmässä työskentelee ryhmäavustaja tai lapsella on henkilökohtainen avustaja.', 80, 'DAYCARE', NULL, NULL),
+    ('40', 'Henkilöstön mitoitukseen ja/tai rakenteeseen liittyvät ratkaisut', 'Henkilökuntalisäys: Lapsen ryhmässä työskentelee lain vaatimaan resurssia enemmän varhaiskasvatuksen lastenhoitajia/sosionomeja/opettajia. Henkilökuntamuutos: Ryhmää on vahvistettu pedagogisesti siten, että henkilöstöön kuuluu kaksi varhaiskasvatuksen opettajaa. Mikäli lapsi on erityisryhmässä tai integroidussa ryhmässä, tätä vaihtoehtoa ei valita.', 90, 'DAYCARE', NULL, NULL),
+    ('50', 'Tuettu varhaiskasvatusryhmä', 'Lapsi on tuetussa varhaiskasvatusryhmässä.', 30, 'DAYCARE', NULL, NULL),
+    ('57', 'Vaativan erityisen tuen varhaiskasvatusryhmä', 'Lapsen ryhmässä työskentelee yhtenä työntekijänä varhaiskasvatuksen erityisopettaja.', 50, 'DAYCARE', NULL, NULL),
+    ('80', 'Tulkitsemispalvelut', NULL, 80, 'DAYCARE', '2025-08-01'::date, NULL),
+    ('90', 'Apuvälineet', NULL, 90, 'DAYCARE', '2025-08-01'::date, NULL),
+    ('100', 'Ryhmän lapsimäärän pienentäminen', NULL, 100, 'DAYCARE', '2025-08-01'::date, NULL),
+    ('110', 'Erityisopettajan antama konsultaatio', NULL, 110, 'DAYCARE', '2025-08-01'::date, NULL),
+    ('120', 'Erityisopettajan antama opetus', NULL, 120, 'DAYCARE', '2025-08-01'::date, NULL),
+
+    -- ended DAYCARE
+    ('70', 'Erityisopettajan antama säännöllinen tuki', 'Ryhmän pienennys rakenteellisen tuen muotona eli lapsiryhmää pienennetään, jotta lasten tuki toteutuu tarkoituksenmukaisesti. Kirjaa myös tuen kerroin kohtaan Tuen tarve.', 70, 'DAYCARE', NULL, '2025-07-31'::date),
+
+    -- ended PRESCHOOL
+    ('55', 'Tuettu esiopetusryhmä', 'Lapsi on tuetussa esiopetusryhmässä.', 40, 'PRESCHOOL', NULL, '2025-07-31'::date),
+    ('60', 'Vaativan erityisen tuen perusopetuksen ryhmä/esiopetus', 'Lapsi saa osa-aikaista erityisopetusta.', 60, 'PRESCHOOL', NULL, '2025-07-31'::date),
+
+    ('200', 'Lapsikohtaiset tukitoimet', NULL, 200, 'PRESCHOOL', '2025-08-01'::date, NULL),
+    ('210', 'Erityisopettajan antama opetus osittain pienryhmässä ja muun opetuksen yhteydessä', NULL, 210, 'PRESCHOOL', '2025-08-01'::date, NULL),
+    ('220', 'Erityisopettajan antama opetus pienryhmässä (kokoaikainen)', NULL, 220, 'PRESCHOOL', '2025-08-01'::date, NULL),
+    ('230', 'Tulkitsemispalvelut', NULL, 230, 'PRESCHOOL', '2025-08-01'::date, NULL),
+    ('240', 'Avustajapalvelut', NULL, 240, 'PRESCHOOL', NULL, NULL),
+    ('250', 'Apuvälineet', NULL, 250, 'PRESCHOOL', '2025-08-01'::date, NULL)
+
 ON CONFLICT (value) DO
 UPDATE SET
     name_fi = EXCLUDED.name_fi,
     description_fi = EXCLUDED.description_fi,
     display_order = EXCLUDED.display_order,
-    category = EXCLUDED.category
+    category = EXCLUDED.category,
+    valid_from = EXCLUDED.valid_from,
+    valid_to = EXCLUDED.valid_to
 WHERE
     assistance_action_option.name_fi <> EXCLUDED.name_fi OR
     assistance_action_option.description_fi IS DISTINCT FROM EXCLUDED.description_fi OR
-    assistance_action_option.display_order <> EXCLUDED.display_order OR
-    assistance_action_option.category <> EXCLUDED.category;
+    assistance_action_option.display_order IS DISTINCT FROM EXCLUDED.display_order OR
+    assistance_action_option.category <> EXCLUDED.category OR
+    assistance_action_option.valid_from IS DISTINCT FROM EXCLUDED.valid_from OR
+    assistance_action_option.valid_to IS DISTINCT FROM EXCLUDED.valid_to;


### PR DESCRIPTION
- New options have `valid_from` dates except when they are split from an existing action option (manual migration cases). 
- All ended have `valid_to` dates. 
- Continuing and category transferred options have no dates.
- Some options have been renamed and some have descriptions added or removed.

Option changes:

Hämeenkyrö:
- 0 ended
- 8 added
- 0 transferred
- 2 split

Kangasala:
- 1 ended
- 7 added
- 1 transferred
- 1 split

Nokia:
- 0 ended
- 7 added
- 0 transferred
- 4 split

Ylöjärvi:
- 3 ended
- 11 added
- 0 transferred
- 1 split