### PR TITLE
chore: add 2026 SFI IDP certificate to production

### DIFF
--- a/infra/deploy/variables/hameenkyro-prod-apps.tfvars
+++ b/infra/deploy/variables/hameenkyro-prod-apps.tfvars
@@ -62,4 +62,4 @@ sfi_msg_service_identifier = "hameenkyro_ws_evaka"
 
 # service: HameenkyroProperties
 
-sfi_idp_certificate_years = [2024]
+sfi_idp_certificate_years = [2024, 2026]

--- a/infra/deploy/variables/kangasala-prod-apps.tfvars
+++ b/infra/deploy/variables/kangasala-prod-apps.tfvars
@@ -65,4 +65,4 @@ jamix_diets_enabled  = true
 kangasala_job_plan_document_archival_enabled     = true
 kangasala_archival_schedule_daily_document_limit = 1000
 
-sfi_idp_certificate_years = [2024]
+sfi_idp_certificate_years = [2024, 2026]

--- a/infra/deploy/variables/lempaala-prod-apps.tfvars
+++ b/infra/deploy/variables/lempaala-prod-apps.tfvars
@@ -62,4 +62,4 @@ jamix_diets_enabled  = true
 
 # service: LempaalaProperties
 
-sfi_idp_certificate_years = [2024]
+sfi_idp_certificate_years = [2024, 2026]

--- a/infra/deploy/variables/nokia-prod-apps.tfvars
+++ b/infra/deploy/variables/nokia-prod-apps.tfvars
@@ -65,4 +65,4 @@ jamix_diets_enabled  = true
 nokia_job_plan_document_archival_enabled     = true
 nokia_archival_schedule_daily_document_limit = 1000
 
-sfi_idp_certificate_years = [2024]
+sfi_idp_certificate_years = [2024, 2026]

--- a/infra/deploy/variables/orivesi-prod-apps.tfvars
+++ b/infra/deploy/variables/orivesi-prod-apps.tfvars
@@ -62,4 +62,4 @@ jamix_diets_enabled  = true
 
 # service: OrivesiProperties
 
-sfi_idp_certificate_years = [2024]
+sfi_idp_certificate_years = [2024, 2026]

--- a/infra/deploy/variables/pirkkala-prod-apps.tfvars
+++ b/infra/deploy/variables/pirkkala-prod-apps.tfvars
@@ -65,4 +65,4 @@ jamix_diets_enabled  = true
 pirkkala_job_plan_document_archival_enabled     = true
 pirkkala_archival_schedule_daily_document_limit = 1000
 
-sfi_idp_certificate_years = [2024]
+sfi_idp_certificate_years = [2024, 2026]

--- a/infra/deploy/variables/tampere-prod-apps.tfvars
+++ b/infra/deploy/variables/tampere-prod-apps.tfvars
@@ -71,4 +71,4 @@ tampere_job_plan_bi_export_jobs_cron    = "0 0 1 * * *"
 tampere_job_plan_document_archival_enabled     = true
 tampere_archival_schedule_daily_document_limit = 2000
 
-sfi_idp_certificate_years = [2024]
+sfi_idp_certificate_years = [2024, 2026]

--- a/infra/deploy/variables/vesilahti-prod-apps.tfvars
+++ b/infra/deploy/variables/vesilahti-prod-apps.tfvars
@@ -62,4 +62,4 @@ sfi_msg_service_identifier = "vesilahti_ws_evaka"
 
 # service: VesilahtiProperties
 
-sfi_idp_certificate_years = [2024]
+sfi_idp_certificate_years = [2024, 2026]

--- a/infra/deploy/variables/ylojarvi-prod-apps.tfvars
+++ b/infra/deploy/variables/ylojarvi-prod-apps.tfvars
@@ -62,4 +62,4 @@ jamix_diets_enabled  = true
 
 # service: YlojarviProperties
 
-sfi_idp_certificate_years = [2024]
+sfi_idp_certificate_years = [2024, 2026]


### PR DESCRIPTION
DVV has published the 2026 Suomi.fi Tunnistus production certificate.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
